### PR TITLE
fix: add "--report-files-glob" to "compare-reports"

### DIFF
--- a/change/monosize-8210a1a9-68b9-4ddb-891f-b0765eb56ceb.json
+++ b/change/monosize-8210a1a9-68b9-4ddb-891f-b0765eb56ceb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add \"--report-files-glob\" to \"compare-reports\"",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/src/commands/compareReports.mts
+++ b/packages/monosize/src/commands/compareReports.mts
@@ -9,7 +9,11 @@ import { compareResultsInReports } from '../utils/compareResultsInReports.mjs';
 import { hrToSeconds } from '../utils/helpers.mjs';
 import { readConfig } from '../utils/readConfig.mjs';
 
-export type CompareReportsOptions = CliOptions & { branch: string; output: 'cli' | 'markdown' };
+export type CompareReportsOptions = CliOptions & {
+  branch: string;
+  'report-files-glob'?: string;
+  output: 'cli' | 'markdown';
+};
 
 async function compareReports(options: CompareReportsOptions) {
   const { branch, output, quiet } = options;
@@ -18,7 +22,9 @@ async function compareReports(options: CompareReportsOptions) {
   const config = await readConfig(quiet);
 
   const localReportStartTime = process.hrtime();
-  const localReport = await collectLocalReport();
+  const localReport = await collectLocalReport({
+    ...(options['report-files-glob'] && { reportFilesGlob: options['report-files-glob'] }),
+  });
 
   if (!quiet) {
     console.log(
@@ -69,6 +75,11 @@ const api: CommandModule<Record<string, unknown>, CompareReportsOptions> = {
       type: 'string',
       description: 'A branch to compare against',
       default: 'main',
+    },
+    'report-files-glob': {
+      type: 'string',
+      description: 'A glob pattern to search for report files in JSON format',
+      required: false,
     },
     output: {
       alias: 'o',

--- a/packages/monosize/src/commands/uploadReport.mts
+++ b/packages/monosize/src/commands/uploadReport.mts
@@ -7,7 +7,7 @@ import { hrToSeconds } from '../utils/helpers.mjs';
 import { readConfig } from '../utils/readConfig.mjs';
 import type { CliOptions } from '../index.mjs';
 
-type UploadOptions = CliOptions & { branch: string; 'report-files-glob': string; 'commit-sha': string };
+type UploadOptions = CliOptions & { branch: string; 'report-files-glob'?: string; 'commit-sha': string };
 
 async function uploadReport(options: UploadOptions) {
   if (!isCI) {


### PR DESCRIPTION
Follow up for #25.

Adds "--report-files-glob" to "compare-reports":

```sh
npx monosize compare-reports --report-files-glob="dist/bundle-size/monosize.json"
```