### PR TITLE
feat: add debug mode to "measure" command

### DIFF
--- a/change/monosize-e3c54ca5-ed10-4796-bda7-b1b00718656e.json
+++ b/change/monosize-e3c54ca5-ed10-4796-bda7-b1b00718656e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add debug mode to \"measure\" command",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prettier": "^2.8.0",
     "pretty-bytes": "^6.0.0",
     "terser": "^5.16.0",
+    "terser-webpack-plugin": "^5.3.1",
     "tslib": "^2.4.1",
     "webpack": "^5.76.0",
     "workspace-tools": "^0.29.1",

--- a/packages/monosize/package.json
+++ b/packages/monosize/package.json
@@ -19,6 +19,7 @@
     "prettier": "^2.8.0",
     "pretty-bytes": "^6.0.0",
     "terser": "^5.16.0",
+    "terser-webpack-plugin": "^5.3.1",
     "tslib": "^2.4.1",
     "webpack": "^5.76.0",
     "workspace-tools": "^0.29.1",

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -7,7 +7,9 @@ export type BuildResult = {
   gzippedSize: number;
 };
 
-export type BundleSizeReportEntry = BuildResult & { packageName: string };
+export type BundleSizeReportEntry = Pick<BuildResult, 'name' | 'path' | 'minifiedSize' | 'gzippedSize'> & {
+  packageName: string;
+};
 export type BundleSizeReport = BundleSizeReportEntry[];
 
 export type StorageAdapter = {

--- a/packages/monosize/src/utils/buildFixture.mts
+++ b/packages/monosize/src/utils/buildFixture.mts
@@ -3,6 +3,7 @@ import { gzipSizeFromFile } from 'gzip-size';
 import fs from 'node:fs';
 import path from 'node:path';
 import { minify } from 'terser';
+import TerserWebpackPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
 import type { Configuration as WebpackConfiguration } from 'webpack';
 
@@ -10,7 +11,7 @@ import { hrToSeconds } from './helpers.mjs';
 import { PreparedFixture } from './prepareFixture.mjs';
 import type { BuildResult, MonoSizeConfig } from '../types.mjs';
 
-function createWebpackConfig(fixturePath: string, outputPath: string): WebpackConfiguration {
+function createWebpackConfig(fixturePath: string, outputPath: string, debug: boolean): WebpackConfiguration {
   return {
     name: 'client',
     target: 'web',
@@ -29,25 +30,70 @@ function createWebpackConfig(fixturePath: string, outputPath: string): WebpackCo
       filename: path.basename(outputPath),
       path: path.dirname(outputPath),
 
-      pathinfo: true,
+      ...(debug && {
+        pathinfo: true,
+      }),
     },
     performance: {
       hints: false,
     },
     optimization: {
-      minimize: false,
+      minimizer: [
+        new TerserWebpackPlugin({
+          extractComments: false,
+          terserOptions: {
+            output: {
+              comments: false,
+            },
+          },
+        }),
+      ],
+
+      // If debug mode is enabled, we want to disable minification and rely on Terser to produce a partially minified
+      // file for debugging purposes
+      ...(debug && {
+        minimize: false,
+        minimizer: [],
+      }),
     },
-    stats: {
-      optimizationBailout: true,
-    },
+
+    ...(debug && {
+      stats: {
+        optimizationBailout: true,
+      },
+    }),
   };
 }
 
-function webpackAsync(webpackConfig: WebpackConfiguration): Promise<null> {
+type RunWebpackOptions = {
+  config: MonoSizeConfig;
+  fixture: PreparedFixture;
+
+  outputPath: string;
+  debug: boolean;
+  quiet: boolean;
+};
+
+async function runWebpack(options: RunWebpackOptions): Promise<null> {
+  const { config, fixture, outputPath, debug, quiet } = options;
+  const webpackStartTime = process.hrtime();
+
+  const webpackConfig = createWebpackConfig(fixture.absolutePath, outputPath, debug);
+  const finalWebpackConfig = config.webpack ? config.webpack(webpackConfig) : webpackConfig;
+
   return new Promise((resolve, reject) => {
-    const compiler = webpack(webpackConfig);
+    const compiler = webpack(finalWebpackConfig);
 
     compiler.run((err, result) => {
+      if (!quiet) {
+        console.log(
+          [
+            pc.blue('[i]'),
+            `"${path.basename(fixture.relativePath)}": Webpack in ${hrToSeconds(process.hrtime(webpackStartTime))}`,
+          ].join(' '),
+        );
+      }
+
       if (err) {
         reject(err);
       }
@@ -60,79 +106,102 @@ function webpackAsync(webpackConfig: WebpackConfiguration): Promise<null> {
   });
 }
 
+type RunTerserOptions = {
+  fixture: PreparedFixture;
+
+  sourcePath: string;
+  outputPath: string;
+  debugOutputPath: string;
+
+  quiet: boolean;
+};
+
+async function runTerser(options: RunTerserOptions) {
+  const { fixture, debugOutputPath, sourcePath, outputPath, quiet } = options;
+
+  const startTime = process.hrtime();
+  const sourceContent = await fs.promises.readFile(sourcePath, 'utf8');
+
+  // Performs only dead-code elimination
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const debugOutput = await minify(sourceContent, {
+    mangle: false,
+    output: {
+      beautify: true,
+      comments: true,
+      preserve_annotations: true,
+    },
+  });
+  // Performs full minification
+  const minifiedOutput = await minify(sourceContent, {
+    output: {
+      comments: false,
+    },
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+
+  if (!debugOutput.code || !minifiedOutput.code) {
+    throw new Error('Got an empty output from Terser, this is not expected...');
+  }
+
+  await fs.promises.writeFile(debugOutputPath, debugOutput.code);
+  await fs.promises.writeFile(outputPath, minifiedOutput.code);
+
+  if (!quiet) {
+    console.log(
+      [
+        pc.blue('[i]'),
+        `"${path.basename(fixture.relativePath)}": Terser in ${hrToSeconds(process.hrtime(startTime))}`,
+      ].join(' '),
+    );
+  }
+}
+
 // ---
+
+type BuildFixtureOptions = {
+  config: MonoSizeConfig;
+  preparedFixture: PreparedFixture;
+  debug: boolean;
+  quiet: boolean;
+};
 
 /**
  * Builds a fixture with Webpack and then minifies it with Terser. Produces two files as artifacts:
  * - partially minified file (.output.js) for debugging
  * - fully minified file (.min.js)
  */
-export async function buildFixture(
-  preparedFixture: PreparedFixture,
-  config: MonoSizeConfig,
-  quiet: boolean,
-): Promise<BuildResult> {
-  const webpackStartTime = process.hrtime();
+export async function buildFixture(options: BuildFixtureOptions): Promise<
+  BuildResult & {
+    outputPath: string;
+    debugOutputPath?: string;
+  }
+> {
+  const { config, debug, preparedFixture, quiet } = options;
 
-  const webpackOutputPath = preparedFixture.absolutePath.replace(/.fixture.js$/, '.output.js');
-  const webpackConfig = createWebpackConfig(preparedFixture.absolutePath, webpackOutputPath);
-  const finalWebpackConfig = config.webpack ? config.webpack(webpackConfig) : webpackConfig;
+  const outputPath = preparedFixture.absolutePath.replace(/\.fixture.js$/, '.output.js');
+  const debugOutputPath = preparedFixture.absolutePath.replace(/\.fixture.js$/, '.debug.js');
 
-  await webpackAsync(finalWebpackConfig);
+  await runWebpack({
+    config,
+    fixture: preparedFixture,
+    outputPath,
+    debug,
+    quiet,
+  });
 
-  if (!quiet) {
-    console.log(
-      [
-        pc.blue('[i]'),
-        `"${path.basename(preparedFixture.relativePath)}": Webpack in ${hrToSeconds(process.hrtime(webpackStartTime))}`,
-      ].join(' '),
-    );
+  if (debug) {
+    await runTerser({
+      fixture: preparedFixture,
+      sourcePath: outputPath,
+      outputPath,
+      debugOutputPath,
+      quiet,
+    });
   }
 
-  // ---
-
-  const terserStartTime = process.hrtime();
-  const terserOutputPath = preparedFixture.absolutePath.replace(/.fixture.js$/, '.min.js');
-
-  const webpackOutput = await fs.promises.readFile(webpackOutputPath, 'utf8');
-
-  const [terserOutput, terserOutputMinified] = await Promise.all([
-    // Performs only dead-code elimination
-    /* eslint-disable @typescript-eslint/naming-convention */
-    minify(webpackOutput, {
-      mangle: false,
-      output: {
-        beautify: true,
-        comments: true,
-        preserve_annotations: true,
-      },
-    }),
-    minify(webpackOutput, {
-      output: {
-        comments: false,
-      },
-    }),
-    /* eslint-enable @typescript-eslint/naming-convention */
-  ]);
-
-  if (!terserOutput.code || !terserOutputMinified.code) {
-    throw new Error('Got an empty output from Terser, this is not expected...');
-  }
-
-  await fs.promises.writeFile(webpackOutputPath, terserOutput.code);
-  await fs.promises.writeFile(terserOutputPath, terserOutputMinified.code);
-
-  if (!quiet) {
-    console.log(
-      [
-        pc.blue('[i]'),
-        `"${path.basename(preparedFixture.relativePath)}": Terser in ${hrToSeconds(process.hrtime(terserStartTime))}`,
-      ].join(' '),
-    );
-  }
-
-  const minifiedSize = (await fs.promises.stat(terserOutputPath)).size;
-  const gzippedSize = await gzipSizeFromFile(terserOutputPath);
+  const minifiedSize = (await fs.promises.stat(outputPath)).size;
+  const gzippedSize = await gzipSizeFromFile(outputPath);
 
   return {
     name: preparedFixture.name,
@@ -140,5 +209,10 @@ export async function buildFixture(
 
     minifiedSize,
     gzippedSize,
+
+    outputPath,
+    ...(debug && {
+      debugOutputPath,
+    }),
   };
 }

--- a/packages/monosize/src/utils/buildFixture.test.mts
+++ b/packages/monosize/src/utils/buildFixture.test.mts
@@ -23,7 +23,7 @@ async function setup(fixtureContent: string): Promise<PreparedFixture> {
   });
   const fixture = tmp.fileSync({
     dir: fixtureDir.name,
-    name: 'test-fixture.js',
+    name: 'test.fixture.js',
   });
 
   await fs.promises.writeFile(fixture.name, fixtureContent);
@@ -42,7 +42,12 @@ const config: MonoSizeConfig = {
     getRemoteReport: vitest.fn(),
     uploadReportToRemote: vitest.fn(),
   },
-  webpack: config => config,
+  webpack: config => {
+    // Disable pathinfo to make the output deterministic in snapshots
+    config.output!.pathinfo = false;
+
+    return config;
+  },
 };
 
 describe('buildFixture', () => {
@@ -51,18 +56,91 @@ describe('buildFixture', () => {
   });
 
   it('builds fixtures and returns minified & GZIP sizes', async () => {
-    const fixturePath = await setup(`console.log('Hello world')`);
-    const buildResult = await buildFixture(fixturePath, config, true);
+    const fixture = await setup(`console.log('Hello world')`);
+    const buildResult = await buildFixture({ preparedFixture: fixture, debug: false, config, quiet: true });
 
     expect(buildResult.name).toBe('Test fixture');
-    expect(buildResult.path).toMatch(/monosize[\\|/]test-fixture.js/);
+    expect(buildResult.path).toMatch(/monosize[\\|/]test\.fixture\.js/);
+    expect(buildResult.outputPath).toMatch(/monosize[\\|/]test\.output\.js/);
 
     expect(buildResult.minifiedSize).toBeGreaterThan(1);
     expect(buildResult.gzippedSize).toBeGreaterThan(1);
   });
 
   it('should throw on compilation errors', async () => {
-    const fixturePath = await setup(`import something from 'unknown-pkg'`);
-    await expect(buildFixture(fixturePath, config, true)).rejects.toBeDefined();
+    const fixture = await setup(`import something from 'unknown-pkg'`);
+    await expect(
+      buildFixture({
+        preparedFixture: fixture,
+        debug: false,
+        config,
+        quiet: true,
+      }),
+    ).rejects.toBeDefined();
+  });
+
+  describe('debug mode', () => {
+    it('does not output additional files when disabled', async () => {
+      const fixture = await setup(`
+      const tokens = {
+        foo: 'foo',
+        bar: 'bar',
+      };
+      function foo () { return tokens.foo; }
+      const bar = 1;
+
+      console.log(foo);
+    `);
+      const buildResult = await buildFixture({
+        preparedFixture: fixture,
+        debug: false,
+        config,
+        quiet: true,
+      });
+      const output = await fs.promises.readFile(buildResult.outputPath, 'utf-8');
+
+      expect(buildResult.outputPath).toMatch(/monosize[\\|/]test\.output\.js/);
+      expect(buildResult.debugOutputPath).toBeUndefined();
+
+      expect(output).toMatchInlineSnapshot('"(()=>{const o=\\"foo\\";console.log((function(){return o}))})();"');
+    });
+
+    it('provides partially minified output when enabled', async () => {
+      const fixture = await setup(`
+      const tokens = {
+        foo: 'foo',
+        bar: 'bar',
+      };
+      function foo () { return tokens.foo; }
+      const bar = 1;
+
+      console.log(foo);
+    `);
+      const buildResult = await buildFixture({
+        preparedFixture: fixture,
+        debug: true,
+        config,
+        quiet: true,
+      });
+
+      expect(buildResult.outputPath).toMatch(/monosize[\\|/]test\.output\.js/);
+      expect(buildResult.debugOutputPath).toMatch(/monosize[\\|/]test\.debug\.js/);
+
+      const output = await fs.promises.readFile(buildResult.outputPath, 'utf-8');
+      const debugOutput = await fs.promises.readFile(buildResult.debugOutputPath!, 'utf-8');
+
+      expect(output).toMatchInlineSnapshot('"(()=>{const o=\\"foo\\";console.log((function(){return o}))})();"');
+
+      // Output should contain the original variable names
+      expect(debugOutput).toMatchInlineSnapshot(`
+      "/******/ (() => {
+          const tokens_foo = \\"foo\\";
+          console.log((function() {
+              return tokens_foo;
+          }));
+      })
+      /******/ ();"
+    `);
+    });
   });
 });

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -1,4 +1,4 @@
-import { sync as globSync } from 'glob';
+import glob from 'glob';
 import fs from 'node:fs';
 import path from 'node:path';
 import { findGitRoot, findPackageRoot } from 'workspace-tools';
@@ -47,7 +47,7 @@ export async function collectLocalReport(options: Partial<CollectLocalReportOpti
     ...options,
   };
 
-  const reportFiles = globSync(reportFilesGlob, { cwd: root });
+  const reportFiles = glob.sync(reportFilesGlob, { cwd: root });
   const reports = await Promise.all(reportFiles.map(readReportForPackage));
 
   return reports.reduce<BundleSizeReport>((acc, { packageName, packageReport }) => {

--- a/packages/monosize/src/utils/collectLocalReport.test.mts
+++ b/packages/monosize/src/utils/collectLocalReport.test.mts
@@ -6,12 +6,16 @@ import tmp from 'tmp';
 // This mock should be not required 😮
 // glob.sync() call in collectLocalReport.ts always returns an empty array on Linux/Windows in tests for an unknown
 // reason while files are present in filesystem
-vitest.mock('glob', () => ({
-  sync: () => [
-    'packages/package-a/dist/bundle-size/monosize.json',
-    'packages/package-b/dist/bundle-size/monosize.json',
-  ],
-}));
+vitest.mock('glob', async () => {
+  const actual = await vitest.importActual<Record<string, unknown>>('glob');
+  return {
+    ...actual,
+    sync: () => [
+      'packages/package-a/dist/bundle-size/monosize.json',
+      'packages/package-b/dist/bundle-size/monosize.json',
+    ],
+  };
+});
 
 import { collectLocalReport } from './collectLocalReport.mjs';
 import type { BuildResult } from '../types.mjs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,13 +396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-string-parser@npm:7.22.5"
-  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/helper-string-parser@npm:7.23.4"
@@ -457,21 +450,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.0":
   version: 7.23.9
   resolution: "@babel/parser@npm:7.23.9"
   bin:
     parser: ./bin/babel-parser.js
   checksum: e7cd4960ac8671774e13803349da88d512f9292d7baa952173260d3e8f15620a28a3701f14f709d769209022f9e7b79965256b8be204fc550cfe783cdcabe7c7
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.0":
-  version: 7.23.0
-  resolution: "@babel/parser@npm:7.23.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 453fdf8b9e2c2b7d7b02139e0ce003d1af21947bbc03eb350fb248ee335c9b85e4ab41697ddbdd97079698de825a265e45a0846bb2ed47a2c7c1df833f42a354
   languageName: node
   linkType: hard
 
@@ -1528,7 +1512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.23.9
   resolution: "@babel/types@npm:7.23.9"
   dependencies:
@@ -1536,17 +1520,6 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.22.20
     to-fast-properties: ^2.0.0
   checksum: 0a9b008e9bfc89beb8c185e620fa0f8ed6c771f1e1b2e01e1596870969096fec7793898a1d64a035176abf1dd13e2668ee30bf699f2d92c210a8128f4b151e65
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.23.0
-  resolution: "@babel/types@npm:7.23.0"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.20
-    to-fast-properties: ^2.0.0
-  checksum: 215fe04bd7feef79eeb4d33374b39909ce9cad1611c4135a4f7fdf41fe3280594105af6d7094354751514625ea92d0875aba355f53e86a92600f290e77b0e604
   languageName: node
   linkType: hard
 
@@ -1880,13 +1853,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/source-map@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@jridgewell/source-map@npm:0.3.2"
+"@jridgewell/source-map@npm:^0.3.3":
+  version: 0.3.5
+  resolution: "@jridgewell/source-map@npm:0.3.5"
   dependencies:
     "@jridgewell/gen-mapping": ^0.3.0
     "@jridgewell/trace-mapping": ^0.3.9
-  checksum: 1b83f0eb944e77b70559a394d5d3b3f98a81fcc186946aceb3ef42d036762b52ef71493c6c0a3b7c1d2f08785f53ba2df1277fe629a06e6109588ff4cdcf7482
+  checksum: 1ad4dec0bdafbade57920a50acec6634f88a0eb735851e0dda906fa9894e7f0549c492678aad1a10f8e144bfe87f238307bf2a914a1bc85b7781d345417e9f6f
   languageName: node
   linkType: hard
 
@@ -1907,13 +1880,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.20
-  resolution: "@jridgewell/trace-mapping@npm:0.3.20"
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.20, @jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.22
+  resolution: "@jridgewell/trace-mapping@npm:0.3.22"
   dependencies:
     "@jridgewell/resolve-uri": ^3.1.0
     "@jridgewell/sourcemap-codec": ^1.4.14
-  checksum: cd1a7353135f385909468ff0cf20bdd37e59f2ee49a13a966dedf921943e222082c583ade2b579ff6cd0d8faafcb5461f253e1bf2a9f48fec439211fdbe788f5
+  checksum: ac7dd2cfe0b479aa1b81776d40d789243131cc792dc8b6b6a028c70fcd6171958ae1a71bf67b618ffe3c0c3feead9870c095ee46a5e30319410d92976b28f498
   languageName: node
   linkType: hard
 
@@ -3156,7 +3129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.10.0, acorn@npm:^8.11.3, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.10.0, acorn@npm:^8.11.3, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.11.3
   resolution: "acorn@npm:8.11.3"
   bin:
@@ -6508,6 +6481,7 @@ __metadata:
     simple-git-hooks: 2.9.0
     syncpack: 11.2.1
     terser: ^5.16.0
+    terser-webpack-plugin: ^5.3.1
     ts-node: 10.9.1
     tslib: ^2.4.1
     typescript: 5.1.6
@@ -7639,12 +7613,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "serialize-javascript@npm:6.0.0"
+"serialize-javascript@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "serialize-javascript@npm:6.0.2"
   dependencies:
     randombytes: ^2.1.0
-  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
+  checksum: c4839c6206c1d143c0f80763997a361310305751171dd95e4b57efee69b8f6edd8960a0b7fbfc45042aadff98b206d55428aee0dc276efe54f100899c7fa8ab7
   languageName: node
   linkType: hard
 
@@ -8118,15 +8092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.3":
-  version: 5.3.1
-  resolution: "terser-webpack-plugin@npm:5.3.1"
+"terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.3.1":
+  version: 5.3.10
+  resolution: "terser-webpack-plugin@npm:5.3.10"
   dependencies:
+    "@jridgewell/trace-mapping": ^0.3.20
     jest-worker: ^27.4.5
     schema-utils: ^3.1.1
-    serialize-javascript: ^6.0.0
-    source-map: ^0.6.1
-    terser: ^5.7.2
+    serialize-javascript: ^6.0.1
+    terser: ^5.26.0
   peerDependencies:
     webpack: ^5.1.0
   peerDependenciesMeta:
@@ -8136,21 +8110,21 @@ __metadata:
       optional: true
     uglify-js:
       optional: true
-  checksum: 1b808fd4f58ce0b532baacc50b9a850fc69ce0077a0e9e5076d4156c52fab3d40b02d5d9148a3eba64630cf7f40057de54f6a5a87fac1849b1f11d6bfdb42072
+  checksum: bd6e7596cf815f3353e2a53e79cbdec959a1b0276f5e5d4e63e9d7c3c5bb5306df567729da287d1c7b39d79093e56863c569c42c6c24cc34c76aa313bd2cbcea
   languageName: node
   linkType: hard
 
-"terser@npm:^5.16.0, terser@npm:^5.7.2":
-  version: 5.16.0
-  resolution: "terser@npm:5.16.0"
+"terser@npm:^5.16.0, terser@npm:^5.26.0":
+  version: 5.27.2
+  resolution: "terser@npm:5.27.2"
   dependencies:
-    "@jridgewell/source-map": ^0.3.2
-    acorn: ^8.5.0
+    "@jridgewell/source-map": ^0.3.3
+    acorn: ^8.8.2
     commander: ^2.20.0
     source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: d035672bd28bd40ff80d83bea6bc6c85bddf41c18060e49c8b36a3aa45a0a6b4a59c6a56bdf52f9d3350587684d664f8ca26656c6084abeb951b85edf34e47ae
+  checksum: 0da083942b10e79b2ed20947c8ebb8dbef729096afdcb82b2f0d730801fb416fd6b1fb4a2869b39679b06cb9b5f27be6d3ffac0c77f329822bd9a4e72016660a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #20.

By avoiding running Terser twice we save around ~20% of build time. At the same time, the debug output could be enabled by adding `--debug` for `measure` i.e.:

```shell
monosize measure --debug
```