### PR TITLE
feat(monosize): add deltaFormat to reporters API configurable via CLI

### DIFF
--- a/change/monosize-b4a407ec-0ea3-47ee-8aab-2d8a5b9ce07b.json
+++ b/change/monosize-b4a407ec-0ea3-47ee-8aab-2d8a5b9ce07b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add deltaFormat to reporters API configurable via CLI",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/src/commands/compareReports.test.mts
+++ b/packages/monosize/src/commands/compareReports.test.mts
@@ -26,7 +26,7 @@ describe('compareReports', () => {
     collectLocalReport.mockImplementation(() => sampleReport);
     compareResultsInReports.mockImplementation(() => sampleComparedReport);
 
-    const options: CompareReportsOptions = { quiet: true, branch: branchName, output: 'cli' };
+    const options: CompareReportsOptions = { quiet: true, branch: branchName, output: 'cli', deltaFormat: 'percent' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await api.handler(options as any);
 
@@ -34,6 +34,7 @@ describe('compareReports', () => {
     expect(compareResultsInReports).toHaveBeenCalledWith(sampleReport, sampleReport);
     expect(cliReporter).toHaveBeenCalledWith(sampleComparedReport, {
       commitSHA: 'test',
+      deltaFormat: 'percent',
       repository: undefined,
       showUnchanged: false,
     });

--- a/packages/monosize/src/reporters/__snapshots__/markdownReporter.test.mts.snap
+++ b/packages/monosize/src/reporters/__snapshots__/markdownReporter.test.mts.snap
@@ -19,3 +19,43 @@ exports[`markdownReporter > renders a report to a file 1`] = `
 <sub>🤖 This report was generated against <a href='https://github.com/microsoft/monosize/commit/commit-hash'>commit-hash</a></sub>
 "
 `;
+
+exports[`markdownReporter > renders a report to a file with different deltaFormat 1`] = `
+"## 📊 Bundle size report
+
+| Package & Exports                                                                      | Baseline (minified/GZIP) |                  PR |                                                                                                                                                                                                 Change |
+| :------------------------------------------------------------------------------------- | -----------------------: | ------------------: | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| <samp>baz-package</samp> <br /> <abbr title='baz.fixture.js'>An entry with diff</abbr> |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` | \`100%\` <img aria-hidden=\\"true\\" src=\\"https://microsoft.github.io/monosize/images/increase.png\\" /><br />\`100%\` <img aria-hidden=\\"true\\" src=\\"https://microsoft.github.io/monosize/images/increase.png\\" /> |
+| <samp>foo-package</samp> <br /> <abbr title='foo.fixture.js'>New entry</abbr>          |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` |                                                                                                                                                                                           🆕 New entry |
+
+<details>
+<summary>Unchanged fixtures</summary>
+
+| Package & Exports                                                                         | Size (minified/GZIP) |
+| ----------------------------------------------------------------------------------------- | -------------------: |
+| <samp>bar-package</samp> <br /> <abbr title='bar.fixture.js'>An entry without diff</abbr> |  \`1 kB\`<br />\`100 B\` |
+
+</details>
+<sub>🤖 This report was generated against <a href='https://github.com/microsoft/monosize/commit/commit-hash'>commit-hash</a></sub>
+"
+`;
+
+exports[`markdownReporter > renders a report to a file with specified "deltaFormat" 1`] = `
+"## 📊 Bundle size report
+
+| Package & Exports                                                                      | Baseline (minified/GZIP) |                  PR |                                                                                                                                                                                                 Change |
+| :------------------------------------------------------------------------------------- | -----------------------: | ------------------: | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| <samp>baz-package</samp> <br /> <abbr title='baz.fixture.js'>An entry with diff</abbr> |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` | \`100%\` <img aria-hidden=\\"true\\" src=\\"https://microsoft.github.io/monosize/images/increase.png\\" /><br />\`100%\` <img aria-hidden=\\"true\\" src=\\"https://microsoft.github.io/monosize/images/increase.png\\" /> |
+| <samp>foo-package</samp> <br /> <abbr title='foo.fixture.js'>New entry</abbr>          |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` |                                                                                                                                                                                           🆕 New entry |
+
+<details>
+<summary>Unchanged fixtures</summary>
+
+| Package & Exports                                                                         | Size (minified/GZIP) |
+| ----------------------------------------------------------------------------------------- | -------------------: |
+| <samp>bar-package</samp> <br /> <abbr title='bar.fixture.js'>An entry without diff</abbr> |  \`1 kB\`<br />\`100 B\` |
+
+</details>
+<sub>🤖 This report was generated against <a href='https://github.com/microsoft/monosize/commit/commit-hash'>commit-hash</a></sub>
+"
+`;

--- a/packages/monosize/src/reporters/cliReporter.test.mts
+++ b/packages/monosize/src/reporters/cliReporter.test.mts
@@ -26,6 +26,7 @@ describe('cliReporter', () => {
     repository: 'https://github.com/microsoft/monosize',
     commitSHA: 'commit-hash',
     showUnchanged: false,
+    deltaFormat: 'percent' as const,
   };
 
   it('wont render anything if there is nothing to compare', () => {
@@ -50,6 +51,24 @@ describe('cliReporter', () => {
       ├────────────────────┼────────┼───────────────────────┤
       │ foo-package        │    N/A │            100%↑ 1 kB │
       │ New entry (new)    │    N/A │           100%↑ 100 B │
+      └────────────────────┴────────┴───────────────────────┘
+    `);
+  });
+
+  it('renders a report to CLI output with specified "deltaFormat"', () => {
+    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+
+    cliReporter(sampleComparedReport, { ...options, deltaFormat: 'delta' });
+
+    expect(log.mock.calls[0][0]).toMatchInlineSnapshot(`
+      ┌────────────────────┬────────┬───────────────────────┐
+      │ Fixture            │ Before │ After (minified/GZIP) │
+      ├────────────────────┼────────┼───────────────────────┤
+      │ baz-package        │    0 B │            1 kB↑ 1 kB │
+      │ An entry with diff │    0 B │          100 B↑ 100 B │
+      ├────────────────────┼────────┼───────────────────────┤
+      │ foo-package        │    N/A │             1 B↑ 1 kB │
+      │ New entry (new)    │    N/A │            1 B↑ 100 B │
       └────────────────────┴────────┴───────────────────────┘
     `);
   });

--- a/packages/monosize/src/reporters/markdownReporter.test.mts
+++ b/packages/monosize/src/reporters/markdownReporter.test.mts
@@ -12,6 +12,7 @@ describe('markdownReporter', () => {
     repository: 'https://github.com/microsoft/monosize',
     commitSHA: 'commit-hash',
     showUnchanged: true,
+    deltaFormat: 'delta' as const,
   };
 
   it('wont render anything if there is nothing to compare', () => {
@@ -32,6 +33,15 @@ describe('markdownReporter', () => {
     const log = vitest.spyOn(console, 'log').mockImplementation(noop);
 
     markdownReporter(sampleComparedReport, options);
+    const output = prettier.format(log.mock.calls[0][0], { parser: 'markdown' });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('renders a report to a file with specified "deltaFormat"', () => {
+    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+
+    markdownReporter(sampleComparedReport, { ...options, deltaFormat: 'percent' });
     const output = prettier.format(log.mock.calls[0][0], { parser: 'markdown' });
 
     expect(output).toMatchSnapshot();

--- a/packages/monosize/src/reporters/shared.mts
+++ b/packages/monosize/src/reporters/shared.mts
@@ -1,6 +1,23 @@
+import type { DiffByMetric } from '../utils/calculateDiffByMetric.mjs';
 import type { ComparedReport } from '../utils/compareResultsInReports.mjs';
+import { formatBytes } from '../utils/helpers.mjs';
 
 export type Reporter = (
   report: ComparedReport,
-  options: { commitSHA: string; repository: string; showUnchanged: boolean },
+  options: { commitSHA: string; repository: string; showUnchanged: boolean; deltaFormat: keyof DiffByMetric },
 ) => void;
+
+export function formatDeltaFactory(
+  diff: DiffByMetric,
+  options: { deltaFormat: keyof DiffByMetric; directionSymbol: (value: number) => string },
+) {
+  const { deltaFormat, directionSymbol } = options;
+
+  if (diff.delta === 0) {
+    return '';
+  }
+
+  const deltaOutput = deltaFormat === 'delta' ? formatBytes(diff[deltaFormat]) : diff[deltaFormat];
+
+  return { deltaOutput, dirSymbol: directionSymbol(diff.delta) };
+}


### PR DESCRIPTION
### Feature

Add new `--delta-format` command flag to `compare-reports`

```sh
# uses percentage comparison within report
monosize compare-reports --delta-format=percent

# uses number/size comparison within report
monosize compare-reports --delta-format=delta
```



---

Closes https://github.com/microsoft/monosize/issues/32