### PR TITLE
feat:BREAKING CHANGE - change create*Bundler api to accept callback handler only

### DIFF
--- a/change/monosize-a7209f39-8ba8-465a-ba0f-af3ae6049089.json
+++ b/change/monosize-a7209f39-8ba8-465a-ba0f-af3ae6049089.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: implement shared interface for createBunlder api",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/monosize-bundler-esbuild-53dd0c0b-96e9-4daa-9082-b333ff52c6cd.json
+++ b/change/monosize-bundler-esbuild-53dd0c0b-96e9-4daa-9082-b333ff52c6cd.json
@@ -1,5 +1,5 @@
 {
-  "type": "major",
+  "type": "minor",
   "comment": "feat:BREAKING CHANGE - change create*Bundler api to accept callback handler only",
   "packageName": "monosize-bundler-esbuild",
   "email": "hochelmartin@gmail.com",

--- a/change/monosize-bundler-esbuild-53dd0c0b-96e9-4daa-9082-b333ff52c6cd.json
+++ b/change/monosize-bundler-esbuild-53dd0c0b-96e9-4daa-9082-b333ff52c6cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat:BREAKING CHANGE - change create*Bundler api to accept callback handler only",
+  "packageName": "monosize-bundler-esbuild",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/monosize-bundler-webpack-9e0708c4-c2eb-4634-9f5f-087e2d07975f.json
+++ b/change/monosize-bundler-webpack-9e0708c4-c2eb-4634-9f5f-087e2d07975f.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat:BREAKING CHANGE - change create*Bundler api to accept callback handler only",
+  "packageName": "monosize-bundler-webpack",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/monosize-bundler-webpack-9e0708c4-c2eb-4634-9f5f-087e2d07975f.json
+++ b/change/monosize-bundler-webpack-9e0708c4-c2eb-4634-9f5f-087e2d07975f.json
@@ -1,5 +1,5 @@
 {
-  "type": "major",
+  "type": "minor",
   "comment": "feat:BREAKING CHANGE - change create*Bundler api to accept callback handler only",
   "packageName": "monosize-bundler-webpack",
   "email": "hochelmartin@gmail.com",

--- a/packages/monosize-bundler-esbuild/src/createEsbuildBundler.mts
+++ b/packages/monosize-bundler-esbuild/src/createEsbuildBundler.mts
@@ -3,18 +3,16 @@ import type { BundlerAdapter } from 'monosize';
 import { runEsbuild } from './runEsbuild.mjs';
 import type { EsbuildBundlerOptions } from './types.mjs';
 
-const DEFAULT_CONFIG_ENHANCER: NonNullable<EsbuildBundlerOptions['enhanceConfig']> = config => config;
+const DEFAULT_CONFIG_ENHANCER: EsbuildBundlerOptions = config => config;
 
-export function createEsbuildBundler(options: EsbuildBundlerOptions = {}): BundlerAdapter {
-  const { enhanceConfig = DEFAULT_CONFIG_ENHANCER } = options;
-
+export function createEsbuildBundler(configEnhancerCallback = DEFAULT_CONFIG_ENHANCER): BundlerAdapter {
   return {
     buildFixture: async function (options) {
       const { fixturePath, quiet } = options;
       const outputPath = fixturePath.replace(/\.fixture.js$/, '.output.js');
 
       await runEsbuild({
-        enhanceConfig,
+        enhanceConfig: configEnhancerCallback,
         fixturePath,
         outputPath,
         quiet,

--- a/packages/monosize-bundler-esbuild/src/runEsbuild.mts
+++ b/packages/monosize-bundler-esbuild/src/runEsbuild.mts
@@ -20,7 +20,7 @@ function createEsbuildConfig(fixturePath: string): BuildOptions {
 }
 
 type RunViteOptions = {
-  enhanceConfig: NonNullable<EsbuildBundlerOptions['enhanceConfig']>;
+  enhanceConfig: EsbuildBundlerOptions;
 
   fixturePath: string;
   outputPath: string;

--- a/packages/monosize-bundler-esbuild/src/runEsbuild.mts
+++ b/packages/monosize-bundler-esbuild/src/runEsbuild.mts
@@ -28,7 +28,7 @@ type RunEsbuildOptions = {
   quiet: boolean;
 };
 
-export async function runEsbuild(options: RunViteOptions): Promise<null> {
+export async function runEsbuild(options: RunEsbuildOptions): Promise<null> {
   const { enhanceConfig, fixturePath, outputPath, quiet } = options;
 
   const startTime = process.hrtime();

--- a/packages/monosize-bundler-esbuild/src/runEsbuild.mts
+++ b/packages/monosize-bundler-esbuild/src/runEsbuild.mts
@@ -19,7 +19,7 @@ function createEsbuildConfig(fixturePath: string): BuildOptions {
   };
 }
 
-type RunViteOptions = {
+type RunEsbuildOptions = {
   enhanceConfig: EsbuildBundlerOptions;
 
   fixturePath: string;

--- a/packages/monosize-bundler-esbuild/src/types.mts
+++ b/packages/monosize-bundler-esbuild/src/types.mts
@@ -1,5 +1,3 @@
 import type { BuildOptions } from 'esbuild';
 
-export type EsbuildBundlerOptions = {
-  enhanceConfig?: (config: BuildOptions) => BuildOptions;
-};
+export type EsbuildBundlerOptions = (config: BuildOptions) => BuildOptions;

--- a/packages/monosize-bundler-esbuild/src/types.mts
+++ b/packages/monosize-bundler-esbuild/src/types.mts
@@ -1,3 +1,4 @@
+import type { BundlerAdapterFactoryConfig } from 'monosize';
 import type { BuildOptions } from 'esbuild';
 
-export type EsbuildBundlerOptions = (config: BuildOptions) => BuildOptions;
+export type EsbuildBundlerOptions = BundlerAdapterFactoryConfig<BuildOptions>;

--- a/packages/monosize-bundler-webpack/src/createWebpackBundler.mts
+++ b/packages/monosize-bundler-webpack/src/createWebpackBundler.mts
@@ -4,11 +4,9 @@ import { runTerser } from './runTerser.mjs';
 import { runWebpack } from './runWebpack.mjs';
 import type { WebpackBundlerOptions } from './types.mjs';
 
-const DEFAULT_CONFIG_ENHANCER: NonNullable<WebpackBundlerOptions['enhanceConfig']> = config => config;
+const DEFAULT_CONFIG_ENHANCER: WebpackBundlerOptions = config => config;
 
-export function createWebpackBundler(options: WebpackBundlerOptions = {}): BundlerAdapter {
-  const { enhanceConfig = DEFAULT_CONFIG_ENHANCER } = options;
-
+export function createWebpackBundler(configEnhancerCallback = DEFAULT_CONFIG_ENHANCER): BundlerAdapter {
   return {
     buildFixture: async function (options) {
       const { debug, fixturePath, quiet } = options;
@@ -17,7 +15,7 @@ export function createWebpackBundler(options: WebpackBundlerOptions = {}): Bundl
       const debugOutputPath = fixturePath.replace(/\.fixture.js$/, '.debug.js');
 
       await runWebpack({
-        enhanceConfig,
+        enhanceConfig: configEnhancerCallback,
         fixturePath,
         outputPath,
         debug,

--- a/packages/monosize-bundler-webpack/src/createWebpackBundler.test.mts
+++ b/packages/monosize-bundler-webpack/src/createWebpackBundler.test.mts
@@ -28,13 +28,12 @@ async function setup(fixtureContent: string): Promise<string> {
   return fixture.name;
 }
 
-const webpackBundler = createWebpackBundler({
-  enhanceConfig: config => {
-    // Disable pathinfo to make the output deterministic in snapshots
-    config.output!.pathinfo = false;
+const webpackBundler = createWebpackBundler(config => {
+  // Disable pathinfo to make the output deterministic in snapshots
+  config.output ??= {};
+  config.output.pathinfo = false;
 
-    return config;
-  },
+  return config;
 });
 
 describe('buildFixture', () => {
@@ -56,7 +55,9 @@ describe('buildFixture', () => {
     });
 
     expect(buildResult.outputPath).toMatch(/monosize[\\|/]test\.output\.js/);
-    expect(await fs.promises.readFile(buildResult.outputPath, 'utf-8')).toMatchInlineSnapshot('"console.log(\\"Hello\\");"');
+    expect(await fs.promises.readFile(buildResult.outputPath, 'utf-8')).toMatchInlineSnapshot(
+      '"console.log(\\"Hello\\");"',
+    );
   });
 
   it('should throw on compilation errors', async () => {

--- a/packages/monosize-bundler-webpack/src/runWebpack.mts
+++ b/packages/monosize-bundler-webpack/src/runWebpack.mts
@@ -62,7 +62,7 @@ function createWebpackConfig(fixturePath: string, outputPath: string, debug: boo
 }
 
 type RunWebpackOptions = {
-  enhanceConfig: NonNullable<WebpackBundlerOptions['enhanceConfig']>;
+  enhanceConfig: WebpackBundlerOptions;
 
   fixturePath: string;
   outputPath: string;

--- a/packages/monosize-bundler-webpack/src/types.mts
+++ b/packages/monosize-bundler-webpack/src/types.mts
@@ -1,3 +1,4 @@
+import type { BundlerAdapterFactoryConfig } from 'monosize';
 import type { Configuration as WebpackConfiguration } from 'webpack';
 
-export type WebpackBundlerOptions = (config: WebpackConfiguration) => WebpackConfiguration;
+export type WebpackBundlerOptions = BundlerAdapterFactoryConfig<WebpackConfiguration>;

--- a/packages/monosize-bundler-webpack/src/types.mts
+++ b/packages/monosize-bundler-webpack/src/types.mts
@@ -1,5 +1,3 @@
 import type { Configuration as WebpackConfiguration } from 'webpack';
 
-export type WebpackBundlerOptions = {
-  enhanceConfig?: (config: WebpackConfiguration) => WebpackConfiguration;
-};
+export type WebpackBundlerOptions = (config: WebpackConfiguration) => WebpackConfiguration;

--- a/packages/monosize/README.md
+++ b/packages/monosize/README.md
@@ -150,7 +150,7 @@ Produces a report file (`dist/bundle-size/monosize.json`) that is used by other 
 Compares local (requires call of `monosize measure` first) and remote results, provides output to CLI or to a Markdown file.
 
 ```sh
-monosize compare-reports --branch=main --output=["cli"|"markdown"] [--quiet]
+monosize compare-reports --branch=main --output=["cli"|"markdown"] --deltaFormat=["delta"|"percent"] [--quiet]
 ```
 
 ### `upload-report`

--- a/packages/monosize/src/index.mts
+++ b/packages/monosize/src/index.mts
@@ -27,6 +27,8 @@ export type {
   MonoSizeConfig,
   BundlerAdapter,
   StorageAdapter,
+  BundlerAdapterFactoryConfig,
+  BundleAdapterFactory,
 } from './types.mjs';
 
 export default cliSetup;

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -34,6 +34,20 @@ export type BundlerAdapter = {
   }>;
 };
 
+/**
+ * @kind shared
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BundlerAdapterFactoryConfig<T extends Record<string, any>> = (config: T) => T;
+
+/**
+ * @kind shared
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BundleAdapterFactory<T extends Record<string, any>> = (
+  options: BundlerAdapterFactoryConfig<T>,
+) => BundlerAdapter;
+
 export type MonoSizeConfig = {
   repository: string;
   storage: StorageAdapter;


### PR DESCRIPTION
### BREAKING CHANGE

This simplifies the bundler api to accept only callback

**Before:**

```js
bundler: webpackBundler({
    enhanceConfig: config => {
      return config;
    },
  }),
```

**After:**

```js
bundler: webpackBundler(config => {
      return config;
  }),
```

### Other features

- introduces unified `createBundler` shared types
  - changes dep graph - bundler packages now rely on monosize 
<img width="1439" alt="image" src="https://github.com/microsoft/monosize/assets/1223799/b2f04f89-2acb-4717-8e4a-9122596d06f9">
 
- updates cli docs