### PR TITLE
ci: add yarn dedupe check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             yarn-cache-folder-
 
       - run: yarn install --immutable
+      - run: yarn dedupe --check
       - run: yarn check-dependencies
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3


### PR DESCRIPTION
to make sure bots wont mess our lock file ( https://github.com/microsoft/monosize/pull/57/commits )