### PR TITLE
feat(monosize): create packageName within reports from package.json or project.json by default and add packageName,packageRoot global configuration options overrides. [BREAKING-CHANGE]

### DIFF
--- a/change/monosize-e88d2b95-c7f5-417e-845e-3d2691dbd238.json
+++ b/change/monosize-e88d2b95-c7f5-417e-845e-3d2691dbd238.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(monosize): create packageName from package.json or project.json by default and add packageName,packageRoot global configuration options overrides. [BREAKING-CHANGE]",
+  "comment": "feat: create packageName from package.json or project.json by default and add packageName,packageRoot global configuration options overrides. [BREAKING-CHANGE]",
   "packageName": "monosize",
   "email": "hochelmartin@gmail.com",
   "dependentChangeType": "patch"

--- a/change/monosize-e88d2b95-c7f5-417e-845e-3d2691dbd238.json
+++ b/change/monosize-e88d2b95-c7f5-417e-845e-3d2691dbd238.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(monosize): create packageName from package.json or project.json by default and add packageName,packageRoot global configuration options overrides. [BREAKING-CHANGE]",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/README.md
+++ b/packages/monosize/README.md
@@ -109,14 +109,27 @@ monosize.config.mjs
 import storageAdapter from 'monosize-storage-*';
 import webpackBundler from 'monosize-bundler-webpack';
 
-export default {
+/** @type {import('monosize').MonoSizeConfig} */
+const config = {
   repository: 'https://github.com/__ORG__/__REPOSITORY__',
   storage: storageAdapter(),
   bundler: webpackBundler(config => {
     // customize config here
     return config;
   }),
+
+  // Optional `compare-reports`/`upload-reports` commands config overrides
+  packageRoot: async reportFile => {
+    // provide custom logic on how to resolve package root
+    return '...';
+  },
+  packageName: async packageRoot => {
+    // provide custom logic on how to resolve packageName used within reports
+    return '...';
+  },
 };
+
+export default config;
 ```
 
 ### Bundler adapters
@@ -160,6 +173,10 @@ Compares local (requires call of `monosize measure` first) and remote results, p
 monosize compare-reports --branch=main --output=["cli"|"markdown"] [--deltaFormat=["delta"|"percent"]] [--report-files-glob] [--quiet]
 ```
 
+> [!TIP]
+> In order to resolve package name used within report, we look for `package.json` or `project.json` by default to identify project root and use `#name` property from obtained configuration.
+> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.packageName` or `MonoSizeConfig.packageRoot`).
+
 #### Options
 
 - `branch` - the branch to compare the results with, usually `main`
@@ -174,6 +191,10 @@ monosize compare-reports --branch=main --output=["cli"|"markdown"] [--deltaForma
 
 > [!TIP]
 > Requires a configured storage adapter.
+
+> [!TIP]
+> In order to resolve package name used within report, we look for `package.json` or `project.json` by default to identify project root and use `#name` property from obtained configuration.
+> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.packageName` or `MonoSizeConfig.packageRoot`).
 
 ```sh
 monosize upload-report --branch=main --commit-sha=HASH [--report-files-glob] [--quiet]

--- a/packages/monosize/README.md
+++ b/packages/monosize/README.md
@@ -119,13 +119,15 @@ const config = {
   }),
 
   // Optional `compare-reports`/`upload-reports` commands config overrides
-  packageRoot: async reportFile => {
-    // provide custom logic on how to resolve package root
-    return '...';
-  },
-  packageName: async packageRoot => {
-    // provide custom logic on how to resolve packageName used within reports
-    return '...';
+  reportResolvers: {
+    packageRoot: async reportFile => {
+      // provide custom logic on how to resolve package root
+      return '...';
+    },
+    packageName: async packageRoot => {
+      // provide custom logic on how to resolve packageName used within reports
+      return '...';
+    },
   },
 };
 
@@ -175,7 +177,7 @@ monosize compare-reports --branch=main --output=["cli"|"markdown"] [--deltaForma
 
 > [!TIP]
 > In order to resolve package name used within report, we look for `package.json` or `project.json` by default to identify project root and use `#name` property from obtained configuration.
-> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.packageName` or `MonoSizeConfig.packageRoot`).
+> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.reportResolvers`).
 
 #### Options
 
@@ -194,7 +196,7 @@ monosize compare-reports --branch=main --output=["cli"|"markdown"] [--deltaForma
 
 > [!TIP]
 > In order to resolve package name used within report, we look for `package.json` or `project.json` by default to identify project root and use `#name` property from obtained configuration.
-> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.packageName` or `MonoSizeConfig.packageRoot`).
+> If you have custom solution that needs changes please use monosize configuration API (`MonoSizeConfig.reportResolvers`).
 
 ```sh
 monosize upload-report --branch=main --commit-sha=HASH [--report-files-glob] [--quiet]

--- a/packages/monosize/src/commands/compareReports.mts
+++ b/packages/monosize/src/commands/compareReports.mts
@@ -25,7 +25,8 @@ async function compareReports(options: CompareReportsOptions) {
 
   const localReportStartTime = process.hrtime();
   const localReport = await collectLocalReport({
-    ...(options['report-files-glob'] && { reportFilesGlob: options['report-files-glob'] }),
+    ...config,
+    reportFilesGlob: options['report-files-glob'] ?? undefined,
   });
 
   if (!quiet) {

--- a/packages/monosize/src/commands/uploadReport.mts
+++ b/packages/monosize/src/commands/uploadReport.mts
@@ -22,7 +22,8 @@ async function uploadReport(options: UploadOptions) {
 
   const localReportStartTime = process.hrtime();
   const localReport = await collectLocalReport({
-    ...(options['report-files-glob'] && { reportFilesGlob: options['report-files-glob'] }),
+    ...config,
+    reportFilesGlob: options['report-files-glob'] ?? undefined,
   });
 
   if (!quiet) {

--- a/packages/monosize/src/reporters/markdownReporter.mts
+++ b/packages/monosize/src/reporters/markdownReporter.mts
@@ -1,6 +1,3 @@
-import { fileURLToPath } from 'node:url';
-import { findPackageRoot } from 'workspace-tools';
-
 import { getChangedEntriesInReport } from '../utils/getChangedEntriesInReport.mjs';
 import { formatBytes } from '../utils/helpers.mjs';
 import type { DiffByMetric } from '../utils/calculateDiffByMetric.mjs';
@@ -32,8 +29,6 @@ function formatDelta(diff: DiffByMetric, deltaFormat: keyof DiffByMetric): strin
 export const markdownReporter: Reporter = (report, options) => {
   const { commitSHA, repository, showUnchanged, deltaFormat } = options;
   const footer = `<sub>🤖 This report was generated against <a href='${repository}/commit/${commitSHA}'>${commitSHA}</a></sub>`;
-
-  assertPackageRoot();
 
   const { changedEntries, unchangedEntries } = getChangedEntriesInReport(report);
 
@@ -100,17 +95,3 @@ export const markdownReporter: Reporter = (report, options) => {
 
   console.log(reportOutput.join('\n'));
 };
-
-function assertPackageRoot() {
-  const dirname = fileURLToPath(new URL('.', import.meta.url));
-  const packageRoot = findPackageRoot(dirname);
-
-  if (!packageRoot) {
-    throw new Error(
-      [
-        'Failed to find a package root (directory that contains "package.json" file)',
-        `Lookup start in: ${dirname}`,
-      ].join('\n'),
-    );
-  }
-}

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -46,4 +46,6 @@ export type MonoSizeConfig = {
   repository: string;
   storage: StorageAdapter;
   bundler: BundlerAdapter;
+  packageName?: (packageRoot: string) => Promise<string>;
+  packagePath?: (filepath: string) => Promise<string>;
 };

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -46,6 +46,19 @@ export type MonoSizeConfig = {
   repository: string;
   storage: StorageAdapter;
   bundler: BundlerAdapter;
+  /**
+   * Override package name resolution used within compare-reports and upload-report.
+   *
+   * By default we try to read package name from "package.json" or "project.json" files.
+   * You can override this behavior by providing your own implementation.
+   */
   packageName?: (packageRoot: string) => Promise<string>;
-  packagePath?: (filepath: string) => Promise<string>;
+  /**
+   *
+   * Override package root resolution used within compare-reports and upload-report.
+   *
+   * By default we try to resolve package root by traversing up the directory tree until we find "package.json" or "project.json" files.
+   * You can override this behavior by providing your own implementation.
+   */
+  packageRoot?: (filepath: string) => Promise<string>;
 };

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -59,6 +59,8 @@ export type MonoSizeConfig = {
    *
    * By default we try to resolve package root by traversing up the directory tree until we find "package.json" or "project.json" files.
    * You can override this behavior by providing your own implementation.
+   *
+   * @param reportFilePath - absolute path to the report file (monosize.json)
    */
-  packageRoot?: (filepath: string) => Promise<string>;
+  packageRoot?: (reportFilePath: string) => Promise<string>;
 };

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -42,10 +42,7 @@ export type BundleAdapterFactory<T extends Record<string, any>> = (
   options: BundlerAdapterFactoryConfig<T>,
 ) => BundlerAdapter;
 
-export type MonoSizeConfig = {
-  repository: string;
-  storage: StorageAdapter;
-  bundler: BundlerAdapter;
+type ReportResolvers = {
   /**
    * Override package name resolution used within compare-reports and upload-report.
    *
@@ -63,4 +60,15 @@ export type MonoSizeConfig = {
    * @param reportFilePath - absolute path to the report file (monosize.json)
    */
   packageRoot?: (reportFilePath: string) => Promise<string>;
+};
+
+export type MonoSizeConfig = {
+  repository: string;
+  storage: StorageAdapter;
+  bundler: BundlerAdapter;
+  /**
+   * Report Commands Configuration Overrides
+   * Use this if you need to customize package name or package root resolution logic within bundle reports.
+   */
+  reportResolvers?: ReportResolvers;
 };

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -2,41 +2,50 @@ import glob from 'glob';
 import fs from 'node:fs';
 import path from 'node:path';
 import { findGitRoot } from 'workspace-tools';
-
-import type { BuildResult, BundleSizeReport, MonoSizeConfig } from '../types.mjs';
 import { findUp } from 'find-up';
 
-async function getPackageName(root: string): Promise<string> {
-  const packageNameSourcesPaths = {
-    packageJson: path.join(root, 'package.json'),
-    projectJson: path.join(root, 'project.json'),
-  };
+import type { BuildResult, BundleSizeReport, MonoSizeConfig } from '../types.mjs';
 
-  const hasPackageJson = fs.existsSync(packageNameSourcesPaths.packageJson);
-  const hasProjectJson = fs.existsSync(packageNameSourcesPaths.projectJson);
+async function getPackageRoot(filepath: string): Promise<string> {
+  const root = await findUp(['package.json', 'project.json'], { cwd: path.dirname(filepath) });
 
-  if (!(hasPackageJson || hasProjectJson)) {
+  if (!root) {
     throw new Error(
       [
         'Failed to find a package root (directory that contains "package.json" or "project.json" file)',
-        `Package root location: ${root}`,
+        `Report file location: ${filepath}`,
+        `Tip: You can override package root resolution by providing "packageRoot" function in the configuration`,
+      ].join('\n'),
+    );
+  }
+
+  return root;
+}
+
+const packageNameConfigFiles: Record<string, (rootConfigPath: string) => Promise<string>> = {
+  'package.json': async (rootConfigPath: string) => JSON.parse(await fs.promises.readFile(rootConfigPath, 'utf8')).name,
+  'project.json': async (rootConfigPath: string) => JSON.parse(await fs.promises.readFile(rootConfigPath, 'utf8')).name,
+};
+async function getPackageName(packageRoot: string): Promise<string> {
+  const getPackageNameFromConfigFile = packageNameConfigFiles[path.basename(packageRoot)];
+
+  if (!getPackageNameFromConfigFile) {
+    throw new Error(
+      [
+        'Package root does not contain "package.json" or "project.json" file',
+        `Package root location: ${packageRoot}`,
+        `Tip: If you use 'packageRoot' config override make sure that it returns one of 'package.json' | 'project.json' file paths or provide also 'packageName' config override that accommodates your packageRoot resolution logic.`,
       ].join('\n'),
     );
   }
 
   try {
-    if (hasPackageJson) {
-      return JSON.parse(fs.readFileSync(packageNameSourcesPaths.packageJson, 'utf8')).name as string;
-    }
-
-    if (hasProjectJson) {
-      return JSON.parse(fs.readFileSync(packageNameSourcesPaths.projectJson, 'utf8')).name as string;
-    }
-
-    throw new Error('Failed to read package name from "package.json" or "project.json"');
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
+    const packageName = await getPackageNameFromConfigFile(packageRoot);
+    return packageName;
+  } catch (err) {
+    throw new Error(
+      [`Failed to read/parse package name from "${packageRoot}" file`, 'Original Error:', err].join('\n'),
+    );
   }
 }
 
@@ -46,24 +55,13 @@ async function getPackageName(root: string): Promise<string> {
  */
 async function readReportForPackage(
   reportFile: string,
-  resolvePackageName = getPackageName,
+  resolvers: typeof defaultResolvers,
 ): Promise<{ packageName: string; packageReport: BuildResult[] }> {
-  const packageRoot = await findUp(['package.json', 'project.json'], { cwd: path.dirname(reportFile) });
-  // const packageRoot = searchUp(reportFile, process.cwd());
-
-  if (!packageRoot) {
-    throw new Error(
-      [
-        'Failed to find a package root (directory that contains "package.json" file)',
-        `Report file location: ${reportFile}`,
-      ].join('\n'),
-    );
-  }
-
-  const packageName = await resolvePackageName(packageRoot);
-  const packageReportJSON = await fs.promises.readFile(reportFile, 'utf8');
+  const packageRoot = await resolvers.packageRoot(reportFile);
+  const packageName = await resolvers.packageName(packageRoot);
 
   try {
+    const packageReportJSON = await fs.promises.readFile(reportFile, 'utf8');
     const packageReport = JSON.parse(packageReportJSON) as BuildResult[];
 
     return { packageName, packageReport };
@@ -77,7 +75,10 @@ type CollectLocalReportOptions = {
   reportFilesGlob: string;
 };
 
-interface Options extends Partial<CollectLocalReportOptions>, Pick<MonoSizeConfig, 'packageName' | 'packagePath'> {}
+type Resolvers = Pick<MonoSizeConfig, 'packageName' | 'packageRoot'>;
+const defaultResolvers = { packageName: getPackageName, packageRoot: getPackageRoot };
+
+interface Options extends Partial<CollectLocalReportOptions>, Resolvers {}
 
 /**
  * Collects all reports for packages to a single one.
@@ -85,6 +86,7 @@ interface Options extends Partial<CollectLocalReportOptions>, Pick<MonoSizeConfi
 export async function collectLocalReport(options: Options): Promise<BundleSizeReport> {
   const {
     packageName,
+    packageRoot,
     reportFilesGlob,
     root = findGitRoot(process.cwd()),
   } = {
@@ -93,8 +95,14 @@ export async function collectLocalReport(options: Options): Promise<BundleSizeRe
     ...options,
   };
 
+  const resolvers = {
+    ...defaultResolvers,
+    packageName,
+    packageRoot,
+  } as Required<Resolvers>;
+
   const reportFiles = glob.sync(reportFilesGlob, { absolute: true, cwd: root });
-  const reports = await Promise.all(reportFiles.map(reportFile => readReportForPackage(reportFile, packageName)));
+  const reports = await Promise.all(reportFiles.map(reportFile => readReportForPackage(reportFile, resolvers)));
 
   return reports.reduce<BundleSizeReport>((acc, { packageName, packageReport }) => {
     const processedReport = packageReport.map(reportEntry => ({ packageName, ...reportEntry }));

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -6,14 +6,14 @@ import { findUp } from 'find-up';
 
 import type { BuildResult, BundleSizeReport, MonoSizeConfig } from '../types.mjs';
 
-async function getPackageRoot(filepath: string): Promise<string> {
-  const rootConfig = await findUp(['package.json', 'project.json'], { cwd: path.dirname(filepath) });
+async function getPackageRoot(reportFilePath: string): Promise<string> {
+  const rootConfig = await findUp(['package.json', 'project.json'], { cwd: path.dirname(reportFilePath) });
 
   if (!rootConfig) {
     throw new Error(
       [
         'Failed to find a package root (directory that contains "package.json" or "project.json" file)',
-        `Report file location: ${filepath}`,
+        `Report file location: ${reportFilePath}`,
         `Tip: You can override package root resolution by providing "packageRoot" function in the configuration`,
       ].join('\n'),
     );
@@ -68,8 +68,7 @@ async function readReportForPackage(
   const packageName = await resolvers.packageName(packageRoot);
 
   try {
-    const packageReportJSON = await fs.promises.readFile(reportFile, 'utf8');
-    const packageReport = JSON.parse(packageReportJSON) as BuildResult[];
+    const packageReport: BuildResult[] = JSON.parse(await fs.promises.readFile(reportFile, 'utf8'));
 
     return { packageName, packageReport };
   } catch (e) {

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -81,7 +81,7 @@ type CollectLocalReportOptions = {
   reportFilesGlob: string;
 };
 
-type Resolvers = Pick<MonoSizeConfig, 'packageName' | 'packageRoot'>;
+type Resolvers = Pick<MonoSizeConfig, 'reportResolvers'>;
 const defaultResolvers = { packageName: getPackageName, packageRoot: getPackageRoot };
 
 interface Options extends Partial<CollectLocalReportOptions>, Resolvers {}
@@ -91,21 +91,16 @@ interface Options extends Partial<CollectLocalReportOptions>, Resolvers {}
  */
 export async function collectLocalReport(options: Options): Promise<BundleSizeReport> {
   const {
-    packageName,
-    packageRoot,
+    reportResolvers,
     reportFilesGlob,
     root = findGitRoot(process.cwd()),
   } = {
     root: undefined,
     reportFilesGlob: 'packages/**/dist/bundle-size/monosize.json',
-    ...defaultResolvers,
     ...options,
   };
 
-  const resolvers = {
-    packageName,
-    packageRoot,
-  };
+  const resolvers = { ...defaultResolvers, ...reportResolvers };
 
   const reportFiles = glob.sync(reportFilesGlob, { absolute: true, cwd: root });
   const reports = await Promise.all(reportFiles.map(reportFile => readReportForPackage(reportFile, resolvers)));

--- a/packages/monosize/src/utils/collectLocalReport.test.mts
+++ b/packages/monosize/src/utils/collectLocalReport.test.mts
@@ -155,7 +155,7 @@ describe('collectLocalReport', () => {
     `);
     });
 
-    it('should local report based on packageRoo and packageName config overrides', async () => {
+    it('should local report based on packageRoot and packageName config overrides', async () => {
       const { packagesDir, rootDir } = mkPackagesDir();
 
       const reportAPath = mkReportDir(packagesDir, 'package-a', 'johny5.json');

--- a/packages/monosize/src/utils/collectLocalReport.test.mts
+++ b/packages/monosize/src/utils/collectLocalReport.test.mts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import tmp from 'tmp';
+import { findUp } from 'find-up';
 
 // This mock should be not required 😮
 // glob.sync() call in collectLocalReport.ts always returns an empty array on Linux/Windows in tests for an unknown
@@ -20,7 +21,6 @@ vitest.mock('glob', async () => {
 
 import { collectLocalReport } from './collectLocalReport.mjs';
 import type { BuildResult } from '../types.mjs';
-import { findUp } from 'find-up';
 
 function mkPackagesDir() {
   const projectDir = tmp.dirSync({ prefix: 'collectLocalReport', unsafeCleanup: true });

--- a/packages/monosize/src/utils/collectLocalReport.test.mts
+++ b/packages/monosize/src/utils/collectLocalReport.test.mts
@@ -124,21 +124,23 @@ describe('collectLocalReport', () => {
       const actual = (
         await collectLocalReport({
           root: rootDir,
-          packageName: async packageRoot => {
-            if (fs.existsSync(path.join(packageRoot, 'package.json'))) {
-              return (
-                JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'package.json'), 'utf-8')).name +
-                '-overridden-pkg'
-              );
-            }
-            if (fs.existsSync(path.join(packageRoot, 'project.json'))) {
-              return (
-                JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'project.json'), 'utf-8')).name +
-                '-overridden-project'
-              );
-            }
+          reportResolvers: {
+            packageName: async packageRoot => {
+              if (fs.existsSync(path.join(packageRoot, 'package.json'))) {
+                return (
+                  JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'package.json'), 'utf-8')).name +
+                  '-overridden-pkg'
+                );
+              }
+              if (fs.existsSync(path.join(packageRoot, 'project.json'))) {
+                return (
+                  JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'project.json'), 'utf-8')).name +
+                  '-overridden-project'
+                );
+              }
 
-            return 'unknown';
+              return 'unknown';
+            },
           },
         })
       ).map(({ packageName }) => ({ packageName }));
@@ -172,20 +174,22 @@ describe('collectLocalReport', () => {
       const actual = (
         await collectLocalReport({
           root: rootDir,
-          packageRoot: async reportFile => {
-            const rootConfig = await findUp('johny5.json', { cwd: path.dirname(reportFile) });
+          reportResolvers: {
+            packageRoot: async reportFile => {
+              const rootConfig = await findUp('johny5.json', { cwd: path.dirname(reportFile) });
 
-            if (rootConfig) {
-              return path.dirname(rootConfig);
-            }
+              if (rootConfig) {
+                return path.dirname(rootConfig);
+              }
 
-            return 'unknown';
-          },
-          packageName: async packageRoot => {
-            return (
-              JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'johny5.json'), 'utf-8')).name +
-              '-not-disassembled'
-            );
+              return 'unknown';
+            },
+            packageName: async packageRoot => {
+              return (
+                JSON.parse(await fs.promises.readFile(path.join(packageRoot, 'johny5.json'), 'utf-8')).name +
+                '-not-disassembled'
+              );
+            },
           },
         })
       ).map(({ packageName }) => ({ packageName }));


### PR DESCRIPTION
## Before

- report package name used within `compare-reports` and `upload-reports` cli command is constructed via project folder name
- no configuration options to tweak this behaviours

## After

**BREAKING CHANGES**

- report package name used within `compare-reports` and `upload-reports` cli command is constructed via `name` property from `package.json` or `project.json`

- new configuration options to tweak behaviours

  - `packageRoot?: async (filepath: string) => Promise<string>`
    - defaults to `(filepath) => findUp(['package.json', 'project.json'], { cwd: path.dirname(filepath) })`

  - `packageName?: async (packageRoot: string) => Promise<string>;`
    - defaults to `package.json#name ?? project.json#name` 

Closes https://github.com/microsoft/monosize/issues/62