### PR TITLE
fix(monosize): resolve default argument resolution bug within collectLocalReport

### DIFF
--- a/change/monosize-518b2a55-5bf5-47ab-8050-1d0f6e02dc64.json
+++ b/change/monosize-518b2a55-5bf5-47ab-8050-1d0f6e02dc64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve default argument resolution bug within collectLocalReport",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/src/commands/compareReports.mts
+++ b/packages/monosize/src/commands/compareReports.mts
@@ -26,7 +26,7 @@ async function compareReports(options: CompareReportsOptions) {
   const localReportStartTime = process.hrtime();
   const localReport = await collectLocalReport({
     ...config,
-    reportFilesGlob: options['report-files-glob'] ?? undefined,
+    reportFilesGlob: options['report-files-glob'],
   });
 
   if (!quiet) {

--- a/packages/monosize/src/commands/uploadReport.mts
+++ b/packages/monosize/src/commands/uploadReport.mts
@@ -23,7 +23,7 @@ async function uploadReport(options: UploadOptions) {
   const localReportStartTime = process.hrtime();
   const localReport = await collectLocalReport({
     ...config,
-    reportFilesGlob: options['report-files-glob'] ?? undefined,
+    reportFilesGlob: options['report-files-glob'],
   });
 
   if (!quiet) {

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -92,13 +92,9 @@ interface Options extends Partial<CollectLocalReportOptions>, Resolvers {}
 export async function collectLocalReport(options: Options): Promise<BundleSizeReport> {
   const {
     reportResolvers,
-    reportFilesGlob,
+    reportFilesGlob = 'packages/**/dist/bundle-size/monosize.json',
     root = findGitRoot(process.cwd()),
-  } = {
-    root: undefined,
-    reportFilesGlob: 'packages/**/dist/bundle-size/monosize.json',
-    ...options,
-  };
+  } = options;
 
   const resolvers = { ...defaultResolvers, ...reportResolvers };
 

--- a/packages/monosize/src/utils/collectLocalReport.test.mts
+++ b/packages/monosize/src/utils/collectLocalReport.test.mts
@@ -65,7 +65,7 @@ describe('collectLocalReport', () => {
     await fs.promises.writeFile(reportAPath, JSON.stringify(reportA));
     await fs.promises.writeFile(reportBPath, JSON.stringify(reportB));
 
-    expect(await collectLocalReport({ root: rootDir })).toMatchInlineSnapshot(`
+    expect(await collectLocalReport({ root: rootDir, reportFilesGlob: undefined })).toMatchInlineSnapshot(`
       [
         {
           "gzippedSize": 50,


### PR DESCRIPTION
0.6 is failing when invoking `compare-reports` https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=343142&view=logs&j=f5e89eef-ad59-58c9-614d-c2fd6081e79d&t=a54a6299-9770-5aec-0235-c3967042cdfd

Fixes regression introduced https://github.com/microsoft/monosize/pull/68