### PR TITLE
fix(monosize): enable strict CLI mode in order to provide proper feedback when invalid commands/flags are used

### DIFF
--- a/change/monosize-87fc37f4-c9fd-4ca7-b916-cb1a6334cf74.json
+++ b/change/monosize-87fc37f4-c9fd-4ca7-b916-cb1a6334cf74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: enable strict CLI mode in order to provide proper feedback when invalid commands/flags are used",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/src/index.mts
+++ b/packages/monosize/src/index.mts
@@ -15,6 +15,7 @@ const cliSetup = yargs(hideBin(process.argv))
     description: 'Suppress verbose build output',
     default: false,
   })
+  .strict()
   .help()
   .scriptName('monosize')
   .version(false).argv;


### PR DESCRIPTION
**BEFORE:**

<img width="947" alt="image" src="https://github.com/microsoft/monosize/assets/1223799/da23f6e1-417f-4e0a-b27b-b48be02d3072">


**AFTER:**

<img width="887" alt="image" src="https://github.com/microsoft/monosize/assets/1223799/e6740463-71ee-479c-ab09-1f6c316d086a">


Closes https://github.com/microsoft/monosize/issues/67