### PR TITLE
feat(monosize): remove workspace-tools from deps

### DIFF
--- a/change/monosize-6ed8656d-6e17-42f7-a9e5-4c68d3a9897a.json
+++ b/change/monosize-6ed8656d-6e17-42f7-a9e5-4c68d3a9897a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: inline findGitRoot func and remove workspace-tools from deps in order to ship less JS",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "terser-webpack-plugin": "^5.3.1",
     "tslib": "^2.4.1",
     "webpack": "^5.76.0",
-    "workspace-tools": "^0.29.1",
     "yargs": "^17.6.2"
   },
   "resolutions": {

--- a/packages/monosize/package.json
+++ b/packages/monosize/package.json
@@ -16,7 +16,6 @@
     "picocolors": "^1.0.0",
     "pretty-bytes": "^6.0.0",
     "tslib": "^2.4.1",
-    "workspace-tools": "^0.29.1",
     "yargs": "^17.6.2"
   }
 }

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -1,7 +1,7 @@
 import glob from 'glob';
 import fs from 'node:fs';
 import path from 'node:path';
-import { findGitRoot } from 'workspace-tools';
+import { execSync } from 'node:child_process';
 import { findUp } from 'find-up';
 
 import type { BuildResult, BundleSizeReport, MonoSizeConfig } from '../types.mjs';
@@ -106,4 +106,10 @@ export async function collectLocalReport(options: Options): Promise<BundleSizeRe
 
     return [...acc, ...processedReport];
   }, []);
+}
+
+function findGitRoot(cwd: string) {
+  const output = execSync('git rev-parse --show-toplevel', { cwd });
+
+  return output.toString().trim();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7307,7 +7307,6 @@ __metadata:
     vite: 5.1.7
     vitest: 0.34.6
     webpack: ^5.76.0
-    workspace-tools: ^0.29.1
     yargs: ^17.6.2
   languageName: unknown
   linkType: soft
@@ -9832,7 +9831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workspace-tools@npm:^0.29.0, workspace-tools@npm:^0.29.1":
+"workspace-tools@npm:^0.29.0":
   version: 0.29.1
   resolution: "workspace-tools@npm:0.29.1"
   dependencies:


### PR DESCRIPTION
We ship unnecessary amount of 3rd party js with `monosize` CLI via `workspace-tools`  from which we use only 1 function https://bundlephobia.com/package/workspace-tools@0.36.4

This PR removes workspace-tools and inlines `findGitRoot` helper internally