### PR TITLE
feat(monosize): add `--fixture` argument to `measure` command to target specific fixture files

### DIFF
--- a/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
+++ b/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "feat: implement --fixtures argument for measure CLI command",
   "packageName": "monosize",
   "email": "ben.keen@gmail.com",

--- a/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
+++ b/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add arg to measure specific fixture files",
+  "comment": "feat: implement --fixtures argument for measure CLI command",
   "packageName": "monosize",
   "email": "ben.keen@gmail.com",
   "dependentChangeType": "patch"

--- a/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
+++ b/change/monosize-190af040-06c8-4534-88ab-f97941ef976d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add arg to measure specific fixture files",
+  "packageName": "monosize",
+  "email": "ben.keen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/README.md
+++ b/packages/monosize/README.md
@@ -29,6 +29,7 @@
 - [Commands](#commands)
   - [`measure`](#measure)
     - [Options](#options)
+    - [Examples](#examples)
   - [`compare-reports`](#compare-reports)
     - [Options](#options-1)
   - [`upload-report`](#upload-report)
@@ -152,7 +153,7 @@ To store reference results and run comparisons you need to use a storage adapter
 ### `measure`
 
 ```sh
-monosize measure [--debug] [--artifacts-location] [--quiet]
+monosize measure [--debug] [--artifacts-location] [--fixtures] [--quiet]
 ```
 
 Builds fixtures and produces artifacts. For each fixture:
@@ -166,6 +167,12 @@ Produces a report file (`dist/bundle-size/monosize.json`) that is used by other 
 #### Options
 
 - `artifacts-location` - defines relative path from the package root where the artifact files will be stored (`monosize.json` & bundler output). If specified, `--report-files-glob` in `monosize collect-reports` & `monosize upload-reports` should be set accordingly.
+- `fixtures` - optional argument to pass a fixture filename or globbing pattern. If not specified, all fixture files matching a `*.fixture.js` pattern will be measured.
+
+#### Examples
+
+`monosize measure --fixtures ba*` - matches any fixtures with filenames starting with `ba`
+`monosize measure --fixtures Fixture.fixture.js` - matches a fixture with the exact filename
 
 ### `compare-reports`
 

--- a/packages/monosize/src/commands/measure.mts
+++ b/packages/monosize/src/commands/measure.mts
@@ -19,7 +19,7 @@ export type MeasureOptions = CliOptions & {
 };
 
 async function measure(options: MeasureOptions) {
-  const { debug = false, quiet, 'artifacts-location': artifactsLocation, fixtures: fixturesGlob = '*.fixture.js' } = options;
+  const { debug = false, quiet, 'artifacts-location': artifactsLocation, fixtures: fixturesGlob } = options;
 
   const startTime = process.hrtime();
   const artifactsDir = path.resolve(process.cwd(), artifactsLocation);

--- a/packages/monosize/src/commands/measure.mts
+++ b/packages/monosize/src/commands/measure.mts
@@ -15,11 +15,11 @@ import type { BuildResult } from '../types.mjs';
 export type MeasureOptions = CliOptions & {
   debug: boolean;
   'artifacts-location': string;
-  fixtures?: string;
+  fixtures: string;
 };
 
 async function measure(options: MeasureOptions) {
-  const { debug = false, quiet, 'artifacts-location': artifactsLocation, fixtures: fixturesGlob } = options;
+  const { debug = false, quiet, 'artifacts-location': artifactsLocation, fixtures: fixturesGlob = '*.fixture.js' } = options;
 
   const startTime = process.hrtime();
   const artifactsDir = path.resolve(process.cwd(), artifactsLocation);
@@ -40,14 +40,13 @@ async function measure(options: MeasureOptions) {
     console.log(`${pc.blue('[i]')} artifacts dir is cleared`);
   }
 
-  const fixtureFilesGlob = fixturesGlob ? fixturesGlob : '*.fixture.js'; 
-  const fixtures = glob.sync(`bundle-size/${fixtureFilesGlob}`, {
+  const fixtures = glob.sync(`bundle-size/${fixturesGlob}`, {
     absolute: true,
     cwd: process.cwd(),
   });
 
   if (!fixtures.length && fixturesGlob) {    
-    console.log(`${pc.red('[e]')} No matching fixtures found for globbing pattern '${fixturesGlob}'`);
+    console.error(`${pc.red('[e]')} No matching fixtures found for globbing pattern '${fixturesGlob}'`);
     process.exit(1);
   }
 
@@ -112,6 +111,11 @@ const api: CommandModule<Record<string, unknown>, MeasureOptions> = {
         'Relative path to the package root where the artifact files will be stored (monosize.json & bundler output). If specified, "--report-files-glob" in "monosize collect-reports" & "monosize upload-reports" should be set accordingly.',
       default: 'dist/bundle-size',
     },
+    fixtures: {
+      type: 'string',
+      description: 'Filename glob pattern to target whatever fixture files you want to measure.',
+      default: '*.fixture.js'
+    }
   },
 };
 

--- a/packages/monosize/src/commands/measure.mts
+++ b/packages/monosize/src/commands/measure.mts
@@ -15,10 +15,11 @@ import type { BuildResult } from '../types.mjs';
 export type MeasureOptions = CliOptions & {
   debug: boolean;
   'artifacts-location': string;
+  fixtures?: string;
 };
 
 async function measure(options: MeasureOptions) {
-  const { debug = false, quiet, 'artifacts-location': artifactsLocation } = options;
+  const { debug = false, quiet, 'artifacts-location': artifactsLocation, fixtures: fixturesGlob } = options;
 
   const startTime = process.hrtime();
   const artifactsDir = path.resolve(process.cwd(), artifactsLocation);
@@ -39,10 +40,16 @@ async function measure(options: MeasureOptions) {
     console.log(`${pc.blue('[i]')} artifacts dir is cleared`);
   }
 
-  const fixtures = glob.sync('bundle-size/*.fixture.js', {
+  const fixtureFilesGlob = fixturesGlob ? fixturesGlob : '*.fixture.js'; 
+  const fixtures = glob.sync(`bundle-size/${fixtureFilesGlob}`, {
     absolute: true,
     cwd: process.cwd(),
   });
+
+  if (!fixtures.length && fixturesGlob) {    
+    console.log(`${pc.red('[e]')} No matching fixtures found for globbing pattern '${fixturesGlob}'`);
+    process.exit(1);
+  }
 
   if (!quiet) {
     console.log(`${pc.blue('[i]')} Measuring bundle size for ${fixtures.length} fixture(s)...`);

--- a/packages/monosize/src/commands/measure.test.mts
+++ b/packages/monosize/src/commands/measure.test.mts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import tmp from 'tmp';
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
-
 import api, { type MeasureOptions } from './measure.mjs';
 
 const buildFixture = vitest.hoisted(() =>
@@ -40,6 +39,19 @@ async function setup(fixtures: { [key: string]: string }) {
     packageDir: packageDir.name,
   };
 }
+const getMockedFixtures = (fixtureNames: string[]) => (
+  fixtureNames.reduce((acc, item) => ({
+    ...acc,
+    [`${item}.fixture.js`]: `
+      console.log("${item}");
+      export default { name: '${item}' };
+    `
+  }), {})
+);
+
+function noop(num?: number) {
+  /* does nothing */
+}
 
 describe('measure', () => {
   beforeEach(() => {
@@ -47,16 +59,7 @@ describe('measure', () => {
   });
 
   it('builds fixtures and created a report', async () => {
-    const { packageDir } = await setup({
-      'foo.fixture.js': `
-        console.log("foo");
-        export default { name: 'foo' };
-      `,
-      'bar.fixture.js': `
-        console.log("bar");
-        export default { name: 'bar' };
-      `,
-    });
+    const { packageDir } = await setup(getMockedFixtures(['foo', 'bar']));
     const options: MeasureOptions = { quiet: true, debug: false, 'artifacts-location': 'output' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await api.handler(options as any);
@@ -89,5 +92,53 @@ describe('measure', () => {
         gzippedSize: expect.any(Number),
       },
     ]);
+  }); 
+
+  it('builds single targeted fixture when full filename passed', async () => {
+    const { packageDir } = await setup(getMockedFixtures(['foo', 'bar', 'baz']));
+    const options: MeasureOptions = { quiet: true, debug: false, 'artifacts-location': 'output', fixtures: 'foo.fixture.js' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await api.handler(options as any);
+
+    // Fixtures
+
+    expect(await fs.readdir(path.resolve(packageDir, 'output'))).toEqual([
+      'foo.fixture.js',
+      'foo.output.js',
+      'monosize.json',
+    ]);
   });
+
+  it('builds only targeted fixtures with pattern passed', async () => {
+    const { packageDir } = await setup(getMockedFixtures(['foo', 'bar', 'baz']));
+    const options: MeasureOptions = { quiet: true, debug: false, 'artifacts-location': 'output', fixtures: 'ba*' };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await api.handler(options as any);
+
+    // Fixtures
+
+    expect(await fs.readdir(path.resolve(packageDir, 'output'))).toEqual([
+      'bar.fixture.js',
+      'bar.output.js',
+      'baz.fixture.js',
+      'baz.output.js',
+      'monosize.json',
+    ]);
+  });
+
+  it('returns exit code of 1 and displays message when fixtures argument fails to match any fixture filename', async () => {
+    const log = vitest.spyOn(console, 'log').mockImplementation(noop);    
+    const mockExit = vitest.spyOn(process, 'exit').mockImplementation(noop as any);
+
+    await setup({});
+    const options: MeasureOptions = { quiet: true, debug: false, 'artifacts-location': 'output', fixtures: 'invalid-filename.js' };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await api.handler(options as any);
+
+    expect(log.mock.calls[0][0]).toMatch(/No matching fixtures found for globbing pattern/);
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
 });


### PR DESCRIPTION
This adds an optional `--fixtures` argument to allow the `monosize measure` command to target specific fixtures by filename or pattern.

README updated with examples. 