### PR TITLE
ci: add new maintainer to monosize package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 
 # Packages
-packages/monosize @layershifter
+packages/monosize @layershifter @hotell
 packages/monosize-storage-azure @layershifter
 packages/monosize-storage-upstash @layershifter


### PR DESCRIPTION
context: if I review and approve PR affecting `monosize` project It still requires approval from @layershifter 