### PR TITLE
chore: bump GH actions, use hashes

### DIFF
--- a/.github/workflows/ci-change.yml
+++ b/.github/workflows/ci-change.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: '16'
+          cache: 'yarn'
+          node-version: '20'
 
       - run: npx beachball check --changehint "Run 'yarn change' to generate a change file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,69 +5,46 @@ on:
       - main
   pull_request:
 
+env:
+  NX_PARALLEL: 4
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
+          cache: 'yarn'
+          node-version: '20'
 
       - run: yarn install --immutable
       - run: yarn dedupe --check
       - run: yarn check-dependencies
-      - run: yarn nx affected --target=lint --parallel --max-parallel=3
-      - run: yarn nx affected --target=build --parallel --max-parallel=3
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
+      - run: yarn nx affected --target=lint,build,test --nxBail
 
   ci-windows:
     runs-on: windows-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: '16'
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
-          restore-keys: |
-            yarn-cache-folder-
+          cache: 'yarn'
+          node-version: '20'
 
       - run: yarn install --immutable
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
+      - run: yarn nx affected --target=test --nxBail

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,4 @@
+compressionLevel: mixed
+enableGlobalCache: false
 nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-3.2.0.cjs


### PR DESCRIPTION
- Updates GH actions, pins to hashes by best practices
- Removes manual calls of `actions/cache` for Yarn
- Changes call of `yarn nx affected` to be more effitient
- Updates `yarnrc` to work with cache of GH action