### PR TITLE
chore: make package.json for public packages up to date following best practices

### DIFF
--- a/change/monosize-7b73fac9-4b25-47fe-8e47-41b20b43d24d.json
+++ b/change/monosize-7b73fac9-4b25-47fe-8e47-41b20b43d24d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add repository field to package.json",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/monosize-bundler-esbuild-10cfe219-525f-4ea9-9427-ce49451c44a9.json
+++ b/change/monosize-bundler-esbuild-10cfe219-525f-4ea9-9427-ce49451c44a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add repository field to package.json",
+  "packageName": "monosize-bundler-esbuild",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/monosize-bundler-webpack-356a50ef-4116-4dc4-aafe-e9a335c3c457.json
+++ b/change/monosize-bundler-webpack-356a50ef-4116-4dc4-aafe-e9a335c3c457.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add repository field to package.json",
+  "packageName": "monosize-bundler-webpack",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/monosize-storage-azure-e2978f15-7bc1-4a3f-bc41-d7ad9e017af8.json
+++ b/change/monosize-storage-azure-e2978f15-7bc1-4a3f-bc41-d7ad9e017af8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add repository field to package.json",
+  "packageName": "monosize-storage-azure",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/monosize-storage-upstash-231477ad-e1e8-48a9-8709-edf8c85d13f3.json
+++ b/change/monosize-storage-upstash-231477ad-e1e8-48a9-8709-edf8c85d13f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add repository field to package.json",
+  "packageName": "monosize-storage-upstash",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/monosize-bundler-esbuild/package.json
+++ b/packages/monosize-bundler-esbuild/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/monosize"
+    "url": "https://github.com/microsoft/monosize",
+    "directory": "packages/monosize-bundler-esbuild"
   },
-  "directory": "packages/monosize-bundler-esbuild",
   "types": "./src/index.d.mts",
   "dependencies": {
     "esbuild": "^0.25.1",

--- a/packages/monosize-bundler-esbuild/package.json
+++ b/packages/monosize-bundler-esbuild/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/monosize"
   },
+  "directory": "packages/monosize-bundler-esbuild",
   "types": "./src/index.d.mts",
   "dependencies": {
     "esbuild": "^0.25.1",

--- a/packages/monosize-bundler-esbuild/package.json
+++ b/packages/monosize-bundler-esbuild/package.json
@@ -2,6 +2,10 @@
   "name": "monosize-bundler-esbuild",
   "version": "0.1.5",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/monosize"
+  },
   "types": "./src/index.d.mts",
   "dependencies": {
     "esbuild": "^0.25.1",

--- a/packages/monosize-bundler-webpack/package.json
+++ b/packages/monosize-bundler-webpack/package.json
@@ -2,6 +2,10 @@
   "name": "monosize-bundler-webpack",
   "version": "0.1.6",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/monosize"
+  },
   "types": "./src/index.d.mts",
   "dependencies": {
     "monosize": "^0.6.3",

--- a/packages/monosize-bundler-webpack/package.json
+++ b/packages/monosize-bundler-webpack/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/monosize"
+    "url": "https://github.com/microsoft/monosize",
+    "directory": "packages/monosize-bundler-webpack"
   },
-  "directory": "packages/monosize-bundler-webpack",
   "types": "./src/index.d.mts",
   "dependencies": {
     "monosize": "^0.6.3",

--- a/packages/monosize-bundler-webpack/package.json
+++ b/packages/monosize-bundler-webpack/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/monosize"
   },
+  "directory": "packages/monosize-bundler-webpack",
   "types": "./src/index.d.mts",
   "dependencies": {
     "monosize": "^0.6.3",

--- a/packages/monosize-storage-azure/package.json
+++ b/packages/monosize-storage-azure/package.json
@@ -2,6 +2,10 @@
   "name": "monosize-storage-azure",
   "version": "0.0.16",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/monosize"
+  },
   "types": "./src/index.d.mts",
   "dependencies": {
     "@azure/data-tables": "^13.2.2",

--- a/packages/monosize-storage-azure/package.json
+++ b/packages/monosize-storage-azure/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/monosize"
   },
+  "directory": "packages/monosize-storage-azure",
   "types": "./src/index.d.mts",
   "dependencies": {
     "@azure/data-tables": "^13.2.2",

--- a/packages/monosize-storage-azure/package.json
+++ b/packages/monosize-storage-azure/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/monosize"
+    "url": "https://github.com/microsoft/monosize",
+    "directory": "packages/monosize-storage-azure"
   },
-  "directory": "packages/monosize-storage-azure",
   "types": "./src/index.d.mts",
   "dependencies": {
     "@azure/data-tables": "^13.2.2",

--- a/packages/monosize-storage-upstash/package.json
+++ b/packages/monosize-storage-upstash/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/monosize"
   },
+  "directory": "packages/monosize-storage-upstash",
   "types": "./src/index.d.mts",
   "dependencies": {
     "@upstash/redis": "^1.18.0",

--- a/packages/monosize-storage-upstash/package.json
+++ b/packages/monosize-storage-upstash/package.json
@@ -2,6 +2,10 @@
   "name": "monosize-storage-upstash",
   "version": "0.0.21",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/monosize"
+  },
   "types": "./src/index.d.mts",
   "dependencies": {
     "@upstash/redis": "^1.18.0",

--- a/packages/monosize-storage-upstash/package.json
+++ b/packages/monosize-storage-upstash/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/monosize"
+    "url": "https://github.com/microsoft/monosize",
+    "directory": "packages/monosize-storage-upstash"
   },
-  "directory": "packages/monosize-storage-upstash",
   "types": "./src/index.d.mts",
   "dependencies": {
     "@upstash/redis": "^1.18.0",

--- a/packages/monosize/package.json
+++ b/packages/monosize/package.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/monosize"
+    "url": "https://github.com/microsoft/monosize",
+    "directory": "packages/monosize"
   },
-  "directory": "packages/monosize",
   "types": "./src/index.d.mts",
   "bin": {
     "monosize": "./bin/monosize.mjs"

--- a/packages/monosize/package.json
+++ b/packages/monosize/package.json
@@ -2,6 +2,10 @@
   "name": "monosize",
   "version": "0.6.3",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/monosize"
+  },
   "types": "./src/index.d.mts",
   "bin": {
     "monosize": "./bin/monosize.mjs"

--- a/packages/monosize/package.json
+++ b/packages/monosize/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/monosize"
   },
+  "directory": "packages/monosize",
   "types": "./src/index.d.mts",
   "bin": {
     "monosize": "./bin/monosize.mjs"


### PR DESCRIPTION
npmjs.com cannot determine where the code is hosted if the repo field in package.json is missing. This omission may confuse users trying to identify the repository's author.
