### PR TITLE
chore: redo bundler logging

### DIFF
--- a/change/monosize-62eebf5a-6557-4e54-bb6c-b53bc6a63341.json
+++ b/change/monosize-62eebf5a-6557-4e54-bb6c-b53bc6a63341.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: remove custom logging, add bundler name",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/monosize-bundler-esbuild-0b5a0dcb-961d-4c3c-9084-9e9b20c7e677.json
+++ b/change/monosize-bundler-esbuild-0b5a0dcb-961d-4c3c-9084-9e9b20c7e677.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: require \"name\" for bundlers",
+  "packageName": "monosize-bundler-esbuild",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/monosize-bundler-webpack-a995d54d-6ab4-4746-95fd-7eab8fdc72c0.json
+++ b/change/monosize-bundler-webpack-a995d54d-6ab4-4746-95fd-7eab8fdc72c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: remove custom logging, add bundler name",
+  "packageName": "monosize-bundler-webpack",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize-bundler-esbuild/package.json
+++ b/packages/monosize-bundler-esbuild/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "esbuild": "^0.25.1",
     "monosize": "^0.6.3",
-    "picocolors": "^1.0.0",
     "tslib": "^2.4.1"
   }
 }

--- a/packages/monosize-bundler-esbuild/src/createEsbuildBundler.mts
+++ b/packages/monosize-bundler-esbuild/src/createEsbuildBundler.mts
@@ -22,5 +22,6 @@ export function createEsbuildBundler(configEnhancerCallback = DEFAULT_CONFIG_ENH
         outputPath,
       };
     },
+    name: 'esbuild',
   };
 }

--- a/packages/monosize-bundler-esbuild/src/helpers.mts
+++ b/packages/monosize-bundler-esbuild/src/helpers.mts
@@ -1,7 +1,0 @@
-import process from 'node:process';
-
-export function hrToSeconds(hrtime: ReturnType<typeof process.hrtime>): string {
-  const raw = hrtime[0] + hrtime[1] / 1e9;
-
-  return raw.toFixed(2) + 's';
-}

--- a/packages/monosize-bundler-esbuild/src/runEsbuild.mts
+++ b/packages/monosize-bundler-esbuild/src/runEsbuild.mts
@@ -1,9 +1,7 @@
 import fs from 'node:fs/promises';
-import pc from 'picocolors';
 import path from 'node:path';
 import { build, type BuildOptions } from 'esbuild';
 
-import { hrToSeconds } from './helpers.mjs';
 import { EsbuildBundlerOptions } from './types.mjs';
 
 function createEsbuildConfig(fixturePath: string): BuildOptions {
@@ -29,9 +27,7 @@ type RunEsbuildOptions = {
 };
 
 export async function runEsbuild(options: RunEsbuildOptions): Promise<null> {
-  const { enhanceConfig, fixturePath, outputPath, quiet } = options;
-
-  const startTime = process.hrtime();
+  const { enhanceConfig, fixturePath, outputPath } = options;
   const esbuildConfig = enhanceConfig(createEsbuildConfig(fixturePath));
 
   const result = await build(esbuildConfig);
@@ -42,12 +38,6 @@ export async function runEsbuild(options: RunEsbuildOptions): Promise<null> {
   }
 
   await fs.writeFile(outputPath, outputFiles[0].contents);
-
-  if (!quiet) {
-    console.log(
-      [pc.blue('[i]'), `"${path.basename(fixturePath)}": Vite in ${hrToSeconds(process.hrtime(startTime))}`].join(' '),
-    );
-  }
 
   return null;
 }

--- a/packages/monosize-bundler-webpack/package.json
+++ b/packages/monosize-bundler-webpack/package.json
@@ -10,7 +10,6 @@
   "types": "./src/index.d.mts",
   "dependencies": {
     "monosize": "^0.6.3",
-    "picocolors": "^1.0.0",
     "terser": "^5.16.0",
     "terser-webpack-plugin": "^5.3.1",
     "tslib": "^2.4.1",

--- a/packages/monosize-bundler-webpack/src/createWebpackBundler.mts
+++ b/packages/monosize-bundler-webpack/src/createWebpackBundler.mts
@@ -39,5 +39,6 @@ export function createWebpackBundler(configEnhancerCallback = DEFAULT_CONFIG_ENH
         }),
       };
     },
+    name: 'Webpack',
   };
 }

--- a/packages/monosize-bundler-webpack/src/helpers.mts
+++ b/packages/monosize-bundler-webpack/src/helpers.mts
@@ -1,7 +1,0 @@
-import process from 'node:process';
-
-export function hrToSeconds(hrtime: ReturnType<typeof process.hrtime>): string {
-  const raw = hrtime[0] + hrtime[1] / 1e9;
-
-  return raw.toFixed(2) + 's';
-}

--- a/packages/monosize-bundler-webpack/src/runTerser.mts
+++ b/packages/monosize-bundler-webpack/src/runTerser.mts
@@ -1,9 +1,5 @@
 import fs from 'node:fs';
-import path from 'node:path';
-import pc from 'picocolors';
 import { minify } from 'terser';
-
-import { hrToSeconds } from './helpers.mjs';
 
 type RunTerserOptions = {
   fixturePath: string;
@@ -16,9 +12,7 @@ type RunTerserOptions = {
 };
 
 export async function runTerser(options: RunTerserOptions) {
-  const { fixturePath, debugOutputPath, sourcePath, outputPath, quiet } = options;
-
-  const startTime = process.hrtime();
+  const { fixturePath, debugOutputPath, sourcePath, outputPath } = options;
   const sourceContent = await fs.promises.readFile(sourcePath, 'utf8');
 
   // Performs only dead-code elimination
@@ -52,12 +46,4 @@ export async function runTerser(options: RunTerserOptions) {
 
   await fs.promises.writeFile(debugOutputPath, debugOutput.code);
   await fs.promises.writeFile(outputPath, minifiedOutput.code);
-
-  if (!quiet) {
-    console.log(
-      [pc.blue('[i]'), `"${path.basename(fixturePath)}": Terser in ${hrToSeconds(process.hrtime(startTime))}`].join(
-        ' ',
-      ),
-    );
-  }
 }

--- a/packages/monosize-bundler-webpack/src/runWebpack.mts
+++ b/packages/monosize-bundler-webpack/src/runWebpack.mts
@@ -1,10 +1,8 @@
-import pc from 'picocolors';
 import path from 'node:path';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
 import type { Configuration as WebpackConfiguration } from 'webpack';
 
-import { hrToSeconds } from './helpers.mjs';
 import { WebpackBundlerOptions } from './types.mjs';
 
 function createWebpackConfig(fixturePath: string, outputPath: string, debug: boolean): WebpackConfiguration {
@@ -72,24 +70,13 @@ type RunWebpackOptions = {
 };
 
 export async function runWebpack(options: RunWebpackOptions): Promise<null> {
-  const { enhanceConfig, fixturePath, outputPath, debug, quiet } = options;
-  const webpackStartTime = process.hrtime();
-
+  const { enhanceConfig, fixturePath, outputPath, debug } = options;
   const webpackConfig = enhanceConfig(createWebpackConfig(fixturePath, outputPath, debug));
 
   return new Promise((resolve, reject) => {
     const compiler = webpack(webpackConfig);
 
     compiler.run((err, result) => {
-      if (!quiet) {
-        console.log(
-          [
-            pc.blue('[i]'),
-            `"${path.basename(fixturePath)}": Webpack in ${hrToSeconds(process.hrtime(webpackStartTime))}`,
-          ].join(' '),
-        );
-      }
-
       if (err) {
         reject(err);
       }

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -26,6 +26,9 @@ export type BundlerAdapter = {
     outputPath: string;
     debugOutputPath?: string;
   }>;
+
+  /** A friendly name of the bundler used for logging. */
+  name: string;
 };
 
 /**


### PR DESCRIPTION
- Adds `name` field for bundlers interface
- Moves logging from bundler adapters to `measure`