### PR TITLE
chore: unify logging

### DIFF
--- a/change/monosize-c82e1067-d113-4774-9e03-72a7444829db.json
+++ b/change/monosize-c82e1067-d113-4774-9e03-72a7444829db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: unify logging",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/.eslintrc.json
+++ b/packages/monosize/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "**/vite.config.*.timestamp*", "**/vitest.config.*.timestamp*"]
+  "ignorePatterns": ["!**/*", "**/vite.config.*.timestamp*", "**/vitest.config.*.timestamp*"],
+  "rules": {
+    "no-console": "error"
+  }
 }

--- a/packages/monosize/src/commands/measure.test.mts
+++ b/packages/monosize/src/commands/measure.test.mts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import tmp from 'tmp';
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import api, { type MeasureOptions } from './measure.mjs';
+import { logger } from '../logger.mjs';
 
 const buildFixture = vitest.hoisted(() =>
   vitest.fn().mockImplementation(async ({ fixturePath }) => {
@@ -141,7 +142,8 @@ describe('measure', () => {
   });
 
   it('returns exit code of 1 and displays message when fixtures argument fails to match any fixture filename', async () => {
-    const errorLog = vitest.spyOn(console, 'error').mockImplementation(noop);
+    const errorLog = vitest.spyOn(logger, 'error').mockImplementation(noop);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockExit = vitest.spyOn(process, 'exit').mockImplementation(noop as any);
 
     await setup({});
@@ -155,7 +157,7 @@ describe('measure', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await api.handler(options as any);
 
-    expect(errorLog.mock.calls[0][0]).toMatch(/No matching fixtures found for globbing pattern 'invalid-filename.js'/)
+    expect(errorLog.mock.calls[0][0]).toMatch(/No matching fixtures found for globbing pattern 'invalid-filename.js'/);
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/monosize/src/logger.mts
+++ b/packages/monosize/src/logger.mts
@@ -1,0 +1,48 @@
+import process from 'node:process';
+import pc from 'picocolors';
+
+import { formatHrTime } from './utils/helpers.mjs';
+
+type LogFunction = (message: unknown, timestamp?: ReturnType<typeof process.hrtime>) => void;
+type LogTypes = 'error' | 'info' | 'success' | 'finish';
+
+export const timestamp = () => process.hrtime();
+
+function toFriendlyTime(time?: ReturnType<typeof process.hrtime>) {
+  if (!time) {
+    return '';
+  }
+
+  return pc.dim(`(${formatHrTime(process.hrtime(time))})`);
+}
+
+/* eslint-disable no-console */
+
+export const logger: Record<LogTypes, LogFunction> & { raw: (...args: unknown[]) => void } = {
+  // Logging functions
+  // These functions are used to log messages to the console with different styles and colors
+  error: (message, time) => {
+    console.error(pc.red('[e]'), message, toFriendlyTime(time));
+  },
+  info: (message, time) => {
+    if (time) {
+      console.info(pc.blue('[i]'), message, toFriendlyTime(time));
+      return;
+    }
+
+    console.info(pc.blue('[i]'), message);
+  },
+  success: (message, time) => {
+    console.log(pc.green('[✔]'), message, toFriendlyTime(time));
+  },
+
+  // Special logging for the end of the process
+  finish: (message, time) => {
+    console.log(pc.bgGreenBright(`  🏁 ${pc.black(message as string)}  `), toFriendlyTime(time));
+  },
+
+  // Raw logging function i.e. console.log()
+  raw: (...args) => {
+    console.log(...args);
+  },
+};

--- a/packages/monosize/src/reporters/cliReporter.mts
+++ b/packages/monosize/src/reporters/cliReporter.mts
@@ -4,6 +4,7 @@ import pc from 'picocolors';
 import { getChangedEntriesInReport } from '../utils/getChangedEntriesInReport.mjs';
 import { formatBytes } from '../utils/helpers.mjs';
 import type { DiffByMetric } from '../utils/calculateDiffByMetric.mjs';
+import { logger } from '../logger.mjs';
 import { formatDeltaFactory, type Reporter } from './shared.mjs';
 
 function getDirectionSymbol(value: number): string {
@@ -38,7 +39,7 @@ export const cliReporter: Reporter = (report, options) => {
   });
 
   if (changedEntries.length === 0) {
-    console.log(`${pc.green('[✔]')} No changes found`);
+    logger.success('No changes found');
     return;
   }
 
@@ -65,7 +66,7 @@ export const cliReporter: Reporter = (report, options) => {
     reportOutput.push([fixtureColumn, beforeColumn, afterColumn]);
   });
 
-  console.log(reportOutput.toString());
-  console.log('');
-  console.log(footer);
+  logger.raw(reportOutput.toString());
+  logger.raw('');
+  logger.raw(footer);
 };

--- a/packages/monosize/src/reporters/cliReporter.test.mts
+++ b/packages/monosize/src/reporters/cliReporter.test.mts
@@ -3,6 +3,7 @@ import { describe, it, expect, vitest } from 'vitest';
 
 import { cliReporter } from './cliReporter.mjs';
 import { sampleComparedReport } from '../__fixture__/sampleComparedReport.mjs';
+import { logger } from '../logger.mjs';
 
 function noop() {
   /* does nothing */
@@ -30,19 +31,19 @@ describe('cliReporter', () => {
   };
 
   it('wont render anything if there is nothing to compare', () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const logSpy = vitest.spyOn(logger, 'success').mockImplementation(noop);
 
     cliReporter([], options);
 
-    expect(log.mock.calls[0][0]).toMatchInlineSnapshot('[✔] No changes found');
+    expect(logSpy.mock.calls[0][0]).toMatchInlineSnapshot('No changes found');
   });
 
   it('renders a report to CLI output', () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const logSpy = vitest.spyOn(console, 'log').mockImplementation(noop);
 
     cliReporter(sampleComparedReport, options);
 
-    expect(log.mock.calls[0][0]).toMatchInlineSnapshot(`
+    expect(logSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
       ┌────────────────────┬────────┬───────────────────────┐
       │ Fixture            │ Before │ After (minified/GZIP) │
       ├────────────────────┼────────┼───────────────────────┤
@@ -56,11 +57,11 @@ describe('cliReporter', () => {
   });
 
   it('renders a report to CLI output with specified "deltaFormat"', () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const logSpy = vitest.spyOn(logger, 'raw').mockImplementation(noop);
 
     cliReporter(sampleComparedReport, { ...options, deltaFormat: 'delta' });
 
-    expect(log.mock.calls[0][0]).toMatchInlineSnapshot(`
+    expect(logSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
       ┌────────────────────┬────────┬───────────────────────┐
       │ Fixture            │ Before │ After (minified/GZIP) │
       ├────────────────────┼────────┼───────────────────────┤

--- a/packages/monosize/src/reporters/markdownReporter.mts
+++ b/packages/monosize/src/reporters/markdownReporter.mts
@@ -2,6 +2,7 @@ import { getChangedEntriesInReport } from '../utils/getChangedEntriesInReport.mj
 import { formatBytes } from '../utils/helpers.mjs';
 import type { DiffByMetric } from '../utils/calculateDiffByMetric.mjs';
 import { formatDeltaFactory, type Reporter } from './shared.mjs';
+import { logger } from '../logger.mjs';
 
 const icons = { increase: 'increase.png', decrease: 'decrease.png' };
 
@@ -36,7 +37,7 @@ export const markdownReporter: Reporter = (report, options) => {
 
   if (changedEntries.length === 0) {
     reportOutput.push(`✅ No changes found`);
-    console.log(reportOutput.join('\n'));
+    logger.raw(reportOutput.join('\n'));
     return;
   }
 
@@ -93,5 +94,5 @@ export const markdownReporter: Reporter = (report, options) => {
   // TODO: use repo settings
   reportOutput.push(footer);
 
-  console.log(reportOutput.join('\n'));
+  logger.raw(reportOutput.join('\n'));
 };

--- a/packages/monosize/src/reporters/markdownReporter.test.mts
+++ b/packages/monosize/src/reporters/markdownReporter.test.mts
@@ -1,8 +1,9 @@
 import prettier from 'prettier';
 import { describe, expect, it, vitest } from 'vitest';
 
-import { markdownReporter } from './markdownReporter.mjs';
 import { sampleComparedReport } from '../__fixture__/sampleComparedReport.mjs';
+import { logger } from '../logger.mjs';
+import { markdownReporter } from './markdownReporter.mjs';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -16,10 +17,10 @@ describe('markdownReporter', () => {
   };
 
   it('wont render anything if there is nothing to compare', async () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const log = vitest.spyOn(logger, 'raw').mockImplementation(noop);
 
     markdownReporter([], options);
-    const output = await prettier.format(log.mock.calls[0][0], { parser: 'markdown' });
+    const output = await prettier.format(log.mock.calls[0][0] as string, { parser: 'markdown' });
 
     expect(output).toMatchInlineSnapshot(`
       "## 📊 Bundle size report
@@ -30,19 +31,19 @@ describe('markdownReporter', () => {
   });
 
   it('renders a report to a file', async () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const rawLog = vitest.spyOn(logger, 'raw').mockImplementation(noop);
 
     markdownReporter(sampleComparedReport, options);
-    const output = await prettier.format(log.mock.calls[0][0], { parser: 'markdown' });
+    const output = await prettier.format(rawLog.mock.calls[0][0] as string, { parser: 'markdown' });
 
     expect(output).toMatchSnapshot();
   });
 
   it('renders a report to a file with specified "deltaFormat"', async () => {
-    const log = vitest.spyOn(console, 'log').mockImplementation(noop);
+    const log = vitest.spyOn(logger, 'raw').mockImplementation(noop);
 
     markdownReporter(sampleComparedReport, { ...options, deltaFormat: 'percent' });
-    const output = await prettier.format(log.mock.calls[0][0], { parser: 'markdown' });
+    const output = await prettier.format(log.mock.calls[0][0] as string, { parser: 'markdown' });
 
     expect(output).toMatchSnapshot();
   });

--- a/packages/monosize/src/utils/helpers.mts
+++ b/packages/monosize/src/utils/helpers.mts
@@ -1,12 +1,21 @@
 import prettyBytes from 'pretty-bytes';
 import process from 'node:process';
 
+/**
+ * Formats a number of bytes into a human-readable string.
+ *
+ * @param value - The number of bytes to format.
+ */
 export function formatBytes(value: number): string {
   return prettyBytes(value, { maximumFractionDigits: 3 });
 }
 
-export function hrToSeconds(hrtime: ReturnType<typeof process.hrtime>): string {
-  const raw = hrtime[0] + hrtime[1] / 1e9;
+export function formatHrTime(hrtime: ReturnType<typeof process.hrtime>): string {
+  const number = hrtime[0] * 1e9 + hrtime[1];
 
-  return raw.toFixed(2) + 's';
+  if (number >= 1e9) {
+    return (number / 1e9).toFixed(2) + 's';
+  }
+
+  return (number / 1e6).toFixed(0) + 'ms';
 }

--- a/packages/monosize/src/utils/helpers.test.mts
+++ b/packages/monosize/src/utils/helpers.test.mts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from 'vitest';
-import { formatBytes } from './helpers.mjs';
+import { formatBytes, formatHrTime } from './helpers.mjs';
 
 describe('formatBytes', () => {
   test('formats bytes to human-readable string', () => {
     expect(formatBytes(124)).toBe('124 B');
     expect(formatBytes(1536)).toBe('1.536 kB');
     expect(formatBytes(1624857)).toBe('1.625 MB');
+  });
+});
+
+describe('formatHrTime', () => {
+  test('formats hrtime to seconds', () => {
+    const hrtime = [1, 500000000] satisfies [number, number]; // 1.5 seconds
+    expect(formatHrTime(hrtime)).toBe('1.50s');
+  });
+
+  test('formats hrtime to milliseconds', () => {
+    const hrtime = [0, 150000000] satisfies [number, number]; // 0.15 seconds
+    expect(formatHrTime(hrtime)).toBe('150ms');
   });
 });

--- a/packages/monosize/src/utils/prepareFixture.mts
+++ b/packages/monosize/src/utils/prepareFixture.mts
@@ -12,7 +12,7 @@ export type PreparedFixture = {
  * Prepares a fixture file to be compiled with a bundler, grabs data from a default export and removes it.
  */
 export async function prepareFixture(artifactDir: string, sourcePath: string): Promise<PreparedFixture> {
-  const sourceFixtureCode = await fs.promises.readFile(sourcePath, 'utf8');
+  const sourceFixtureCode = fs.readFileSync(sourcePath, 'utf8');
 
   // A transform that:
   // - reads metadata (name, threshold, etc.)

--- a/packages/monosize/src/utils/prepareFixture.test.mts
+++ b/packages/monosize/src/utils/prepareFixture.test.mts
@@ -50,7 +50,7 @@ export default { name: 'Test fixture' }
     expect(fixtureData.artifactPath).toBe(path.resolve(artifactsDir, 'test-fixture.js'));
     expect(fixtureData.name).toBe('Test fixture');
 
-    expect(await fs.promises.readFile(fixtureData.artifactPath, 'utf8')).toMatchInlineSnapshot(
+    expect(fs.readFileSync(fixtureData.artifactPath, 'utf8')).toMatchInlineSnapshot(
       `
       "import Component from '@react-component';
 

--- a/packages/monosize/src/utils/readConfig.mts
+++ b/packages/monosize/src/utils/readConfig.mts
@@ -1,7 +1,7 @@
 import { findUp } from 'find-up';
 import { pathToFileURL } from 'node:url';
-import pc from 'picocolors';
 
+import { logger } from '../logger.mjs';
 import type { MonoSizeConfig } from '../types.mjs';
 
 const CONFIG_FILE_NAME = ['monosize.config.js', 'monosize.config.mjs'];
@@ -21,12 +21,12 @@ export async function readConfig(quiet = true): Promise<MonoSizeConfig> {
   const configPath = await findUp(CONFIG_FILE_NAME, { cwd: process.cwd() });
 
   if (!configPath) {
-    console.log([pc.red('[e]'), `No config file found in ${configPath}`].join(' '));
+    logger.error(`No config file found in ${configPath}`);
     process.exit(1);
   }
 
   if (!quiet) {
-    console.log([pc.blue('[i]'), `Using following config ${configPath}`].join(' '));
+    logger.info(`Using following config ${configPath}`);
   }
 
   const configFile = await import(pathToFileURL(configPath).toString());


### PR DESCRIPTION
Unifies all `console.log()` calls into a single logging interface. Probably not the best implementation and 3rd party dependency might be nicer, but it's better than scattered `console.log` calls 🐱 