### PR TITLE
chore: bump Node.js to 24 and update GitHub Actions to latest

### DIFF
--- a/.github/workflows/ci-change.yml
+++ b/.github/workflows/ci-change.yml
@@ -12,12 +12,12 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: npx beachball check --changehint "Run 'yarn change' to generate a change file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,17 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: 'yarn'
-          node-version: '20'
+          node-version: '24'
 
       - run: yarn install --immutable
       - run: yarn dedupe --check
@@ -44,17 +44,17 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: 'yarn'
-          node-version: '20'
+          node-version: '24'
 
       - run: yarn install --immutable
       - run: yarn nx affected --target=test --nxBail

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ extends:
 
               - task: NodeTool@0
                 inputs:
-                  versionSpec: '20.x'
+                  versionSpec: '24.x'
                   checkLatest: true
                 displayName: 'Install Node.js'
 


### PR DESCRIPTION
## Summary

- Bump Node.js from 20 to 24 across all CI configs (GH Actions + Azure Pipelines)
- Bump `actions/checkout` from v4.2.2 to v6.0.2
- Bump `actions/setup-node` from v4.3.0 to v6.3.0
- Bump `nrwl/nx-set-shas` from v4.3.0 to v5.0.1

## Test plan

- [ ] CI passes on this PR (ubuntu + windows jobs)
- [ ] Changelog check workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)