### PR TITLE
fix(monosize): use dist path in bin script

### DIFF
--- a/change/monosize-b74109d6-6cca-4f9e-b055-24b9038fd4ac.json
+++ b/change/monosize-b74109d6-6cca-4f9e-b055-24b9038fd4ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bin script to import from dist instead of src",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/bin/monosize.mjs
+++ b/packages/monosize/bin/monosize.mjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-await import('../src/index.mjs');
+await import('../dist/index.mjs');


### PR DESCRIPTION
## Summary

- Fix `bin/monosize.mjs` to import from `../dist/index.mjs` instead of `../src/index.mjs`
- The published package only includes `bin/` and `dist/` directories, so the `src/` import would fail for consumers

## Test plan

- [ ] Verify `npx monosize` resolves correctly after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)