### PR TITLE
chore: add precommit hook to sync lockfile after version bumps

### DIFF
--- a/beachball.hooks.js
+++ b/beachball.hooks.js
@@ -54,4 +54,9 @@ module.exports = {
       completedPrepublish = true;
     }
   },
+  // Runs once after all bumps, before committing — update lockfile so it stays in sync
+  async precommit() {
+    // --no-immutable: Yarn 4 auto-enables immutable installs in CI, but we need to update the lockfile after version bumps
+    await sh('yarn install --no-immutable');
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7576,7 +7576,7 @@ __metadata:
   resolution: "monosize-bundler-esbuild@workspace:packages/monosize-bundler-esbuild"
   dependencies:
     esbuild: "npm:^0.27.3"
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     tslib: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
@@ -7586,7 +7586,7 @@ __metadata:
   resolution: "monosize-bundler-rspack@workspace:packages/monosize-bundler-rspack"
   dependencies:
     "@rsbuild/core": "npm:^1.6.13"
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     tslib: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
@@ -7595,7 +7595,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monosize-bundler-webpack@workspace:packages/monosize-bundler-webpack"
   dependencies:
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     terser: "npm:^5.16.0"
     terser-webpack-plugin: "npm:^5.3.17"
     tslib: "npm:^2.4.1"
@@ -7667,7 +7667,7 @@ __metadata:
   dependencies:
     "@azure/data-tables": "npm:^13.3.2"
     "@azure/identity": "npm:^4.13.0"
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     tslib: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
@@ -7678,7 +7678,7 @@ __metadata:
   dependencies:
     "@octokit/rest": "npm:^21.1.1"
     adm-zip: "npm:^0.5.16"
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     tslib: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
@@ -7688,12 +7688,12 @@ __metadata:
   resolution: "monosize-storage-upstash@workspace:packages/monosize-storage-upstash"
   dependencies:
     "@upstash/redis": "npm:^1.34.6"
-    monosize: "npm:^0.8.0"
+    monosize: "npm:^0.8.1"
     tslib: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
 
-"monosize@npm:^0.8.0, monosize@workspace:packages/monosize":
+"monosize@npm:^0.8.1, monosize@workspace:packages/monosize":
   version: 0.0.0-use.local
   resolution: "monosize@workspace:packages/monosize"
   dependencies:


### PR DESCRIPTION
## Summary

- Add `precommit` hook to `beachball.hooks.js` that runs `yarn install --no-immutable` after version bumps
- This keeps `yarn.lock` in sync with bumped package versions during publish, matching the pattern used in [griffel](https://github.com/microsoft/griffel/blob/main/beachball.hooks.js)

## Test plan

- [ ] Verify `beachball publish` updates the lockfile before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)