### PR TITLE
chore: add AssetType union + readConfig defaulting

### DIFF
--- a/change/monosize-4d3671e4-8716-4ad7-9d94-416abef96955.json
+++ b/change/monosize-4d3671e4-8716-4ad7-9d94-416abef96955.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add AssetType union and assetTypes config plumbing (dormant)",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -5,8 +5,25 @@ export type BuildResult = {
   gzippedSize: number;
 };
 
+/**
+ * Closed union of asset types monosize knows how to measure today.
+ * Adding a member is purely additive — existing keys are unchanged
+ * and consumers using `Partial<Record<AssetType, AssetSize>>` see the
+ * new key as valid.
+ */
+export type AssetType = 'js' | 'json' | 'css';
+
+export type AssetSize = Pick<BuildResult, 'minifiedSize' | 'gzippedSize'>;
+
 export type BundleSizeReportEntry = Pick<BuildResult, 'name' | 'path' | 'minifiedSize' | 'gzippedSize'> & {
   packageName: string;
+  /**
+   * Per-asset-type breakdown. Keys are members of `AssetType`; only types
+   * that produced output appear. Always populated by `measure` (possibly
+   * `{}` when no allowlisted extension matched). May be absent on entries
+   * returned from storage written before this change.
+   */
+  assets?: Partial<Record<AssetType, AssetSize>>;
 };
 export type BundleSizeReport = BundleSizeReportEntry[];
 
@@ -102,4 +119,21 @@ export type MonoSizeConfig = {
    * It should be a string with a number and unit. Format: `0.5 kB`, `1kB, `10%`.
    */
   threshold?: string;
+
+  /**
+   * Asset types to measure. Each entry must be a member of `AssetType`
+   * (`'js' | 'json' | 'css'`). Files of other types in the bundler output
+   * directory are ignored. Default: `['js', 'css', 'json']`.
+   */
+  assetTypes?: AssetType[];
+};
+
+/**
+ * Internal config shape returned by `readConfig` after defaults and
+ * validation have been applied. Not exported from the public package
+ * surface; downstream commands consume this directly so they don't
+ * need to re-apply defaults.
+ */
+export type LoadedMonoSizeConfig = Omit<MonoSizeConfig, 'assetTypes'> & {
+  assetTypes: AssetType[];
 };

--- a/packages/monosize/src/utils/readConfig.mts
+++ b/packages/monosize/src/utils/readConfig.mts
@@ -2,17 +2,36 @@ import { any as findUp } from 'empathic/find';
 import { pathToFileURL } from 'node:url';
 
 import { logger } from '../logger.mjs';
-import type { MonoSizeConfig } from '../types.mjs';
+import type { AssetType, LoadedMonoSizeConfig, MonoSizeConfig } from '../types.mjs';
 
 const CONFIG_FILE_NAME = ['monosize.config.js', 'monosize.config.mjs'];
 
-let cache: MonoSizeConfig | undefined;
+const KNOWN_ASSET_TYPES: readonly AssetType[] = ['js', 'json', 'css'];
+const DEFAULT_ASSET_TYPES: readonly AssetType[] = ['js', 'json', 'css'];
+
+let cache: LoadedMonoSizeConfig | undefined;
 
 export function resetConfigCache(): void {
   cache = undefined;
 }
 
-export async function readConfig(quiet = true): Promise<MonoSizeConfig> {
+function resolveAssetTypes(input: MonoSizeConfig['assetTypes']): AssetType[] {
+  if (input === undefined) {
+    return [...DEFAULT_ASSET_TYPES].sort();
+  }
+
+  for (const entry of input) {
+    if (!KNOWN_ASSET_TYPES.includes(entry)) {
+      throw new Error(
+        `Unknown assetType "${entry}" in monosize.config. Allowed: ${KNOWN_ASSET_TYPES.join(', ')}`,
+      );
+    }
+  }
+
+  return Array.from(new Set(input)).sort();
+}
+
+export async function readConfig(quiet = true): Promise<LoadedMonoSizeConfig> {
   // don't use the cache in tests
   if (cache && process.env.NODE_ENV !== 'test') {
     return cache;
@@ -30,10 +49,13 @@ export async function readConfig(quiet = true): Promise<MonoSizeConfig> {
   }
 
   const configFile = await import(pathToFileURL(configPath).toString());
-  // TODO: config validation via schema
-  const userConfig = configFile.default;
+  // TODO: full config validation via schema
+  const userConfig = configFile.default as MonoSizeConfig;
 
-  cache = { ...userConfig } as MonoSizeConfig;
+  cache = {
+    ...userConfig,
+    assetTypes: resolveAssetTypes(userConfig.assetTypes),
+  };
 
   return cache;
 }

--- a/packages/monosize/src/utils/readConfig.test.mts
+++ b/packages/monosize/src/utils/readConfig.test.mts
@@ -76,4 +76,30 @@ describe('readConfig', () => {
       repository: '@microsoft/monosize',
     });
   });
+
+  describe('assetTypes', () => {
+    it('defaults to [css, js, json] (sorted) when omitted', async () => {
+      await setup({ repository: '@microsoft/monosize' });
+      const config = await readConfig(true);
+      expect(config.assetTypes).toEqual(['css', 'js', 'json']);
+    });
+
+    it('passes through valid assetTypes (sorted, deduped)', async () => {
+      await setup({ repository: '@microsoft/monosize', assetTypes: ['js', 'css'] });
+      const config = await readConfig(true);
+      expect(config.assetTypes).toEqual(['css', 'js']);
+    });
+
+    it('deduplicates assetTypes', async () => {
+      await setup({ repository: '@microsoft/monosize', assetTypes: ['js', 'js', 'css'] });
+      const config = await readConfig(true);
+      expect(config.assetTypes).toEqual(['css', 'js']);
+    });
+
+    it('throws on unknown assetType entry', async () => {
+      // @ts-expect-error — testing runtime guard for untyped configs
+      await setup({ repository: '@microsoft/monosize', assetTypes: ['svg'] });
+      await expect(readConfig(true)).rejects.toThrow(/unknown assetType "svg".*allowed: js, json, css/i);
+    });
+  });
 });


### PR DESCRIPTION
**Stack 2/7** — depends on #196 (merge first). Stack root: [#172](https://github.com/microsoft/monosize/issues/172).

## Summary
- Adds the closed `AssetType = 'js' | 'json' | 'css'` union, the `AssetSize` type, an optional `assets?: Partial<Record<AssetType, AssetSize>>` field on `BundleSizeReportEntry`, and an optional `assetTypes?: AssetType[]` field on `MonoSizeConfig`.
- `readConfig.mts` now applies the default (`['css','js','json']`), validates each entry against the known set with a clear error for typos in untyped `.mjs` configs, and dedupes. Returns an internal `LoadedMonoSizeConfig` shape where `assetTypes` is a guaranteed `AssetType[]`.
- All new types and config plumbing are dormant — no consumer reads `.assetTypes` yet.

> ⚠️ Subsequent PRs wire it through measure and reporters.


🤖 Generated with [Claude Code](https://claude.com/claude-code)