### PR TITLE
feat: markdown reporter renders per-asset-type breakdown

### DIFF
--- a/change/monosize-14517884-2b25-4e85-b227-5817e86f4d74.json
+++ b/change/monosize-14517884-2b25-4e85-b227-5817e86f4d74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "internal: share hasMovedAssetDelta predicate; markdown reporter mirrors cli single-type suppression",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/monosize/src/reporters/__snapshots__/markdownReporter.test.mts.snap
+++ b/packages/monosize/src/reporters/__snapshots__/markdownReporter.test.mts.snap
@@ -8,6 +8,14 @@ exports[`markdownReporter > renders a report to a file 1`] = `
 | <samp>baz-package</samp> <br /> <abbr title='baz.fixture.js'>An entry with diff</abbr> |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` | \`1 kB\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /><br />\`100 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> |
 | <samp>foo-package</samp> <br /> <abbr title='foo.fixture.js'>New entry</abbr>          |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` |                                                                                                                                                                                            🆕 New entry |
 
+### Breakdown
+
+<details><summary><samp>baz-package</samp> · An entry with diff</summary>
+
+- \`css\`: \`300 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`30 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+- \`js\`: \`700 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`70 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+</details>
+
 <details>
 <summary>Unchanged fixtures</summary>
 
@@ -28,6 +36,14 @@ exports[`markdownReporter > renders a report to a file with specified "deltaForm
 | <samp>baz-package</samp> <br /> <abbr title='baz.fixture.js'>An entry with diff</abbr> |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` | \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /><br />\`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> |
 | <samp>foo-package</samp> <br /> <abbr title='foo.fixture.js'>New entry</abbr>          |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` |                                                                                                                                                                                           🆕 New entry |
 
+### Breakdown
+
+<details><summary><samp>baz-package</samp> · An entry with diff</summary>
+
+- \`css\`: \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+- \`js\`: \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+</details>
+
 <details>
 <summary>Unchanged fixtures</summary>
 
@@ -46,6 +62,14 @@ exports[`markdownReporter > renders a report with exceeded threshold 1`] = `
 | Package & Exports                                                                                               | Baseline (minified/GZIP) |                  PR |                                                                                                                                                                                                 Change |
 | :-------------------------------------------------------------------------------------------------------------- | -----------------------: | ------------------: | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | <samp>baz-package</samp> <br /> <abbr title='baz.fixture.js'>An entry with diff</abbr> <br /> ⚠️ over threshold |         \`0 B\`<br />\`0 B\` | \`1 kB\`<br />\`100 B\` | \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /><br />\`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> |
+
+### Breakdown
+
+<details><summary><samp>baz-package</samp> · An entry with diff</summary>
+
+- \`css\`: \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+- \`js\`: \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`100%\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+</details>
 
 <details>
 <summary>Unchanged fixtures</summary>

--- a/packages/monosize/src/reporters/cliReporter.mts
+++ b/packages/monosize/src/reporters/cliReporter.mts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util';
 
 import { getChangedEntriesInReport } from '../utils/getChangedEntriesInReport.mjs';
 import { formatBytes } from '../utils/helpers.mjs';
-import type { AssetDiff, DiffByMetric } from '../utils/calculateDiff.mjs';
+import { hasMovedAssetDelta, type AssetDiff, type DiffByMetric } from '../utils/calculateDiff.mjs';
 import type { ComparedReportEntry } from '../utils/compareResultsInReports.mjs';
 import { logger } from '../logger.mjs';
 import { formatDeltaFactory, type Reporter } from './shared.mjs';
@@ -20,9 +20,7 @@ function formatDelta(diff: DiffByMetric, deltaFormat: keyof DiffByMetric): strin
   const output = formatDeltaFactory(diff, { deltaFormat, directionSymbol: getDirectionSymbol });
   const color = diff.delta > 0 ? ('red' as const) : ('green' as const);
 
-  return typeof output === 'string'
-    ? output
-    : styleText(color, output.deltaOutput + output.dirSymbol);
+  return typeof output === 'string' ? output : styleText(color, output.deltaOutput + output.dirSymbol);
 }
 
 function buildEntryRow(entry: ComparedReportEntry, deltaFormat: keyof DiffByMetric): Row {
@@ -54,14 +52,11 @@ function buildEntryRow(entry: ComparedReportEntry, deltaFormat: keyof DiffByMetr
  * stored `assets.svg`) still surfaces. Returns `[]` when only a single
  * type changed — that sub-row would just duplicate the top-level total.
  */
-function buildBreakdownRows(
-  assetsDiff: Record<string, AssetDiff> | undefined,
-  deltaFormat: keyof DiffByMetric,
-): Row[] {
+function buildBreakdownRows(assetsDiff: Record<string, AssetDiff> | undefined, deltaFormat: keyof DiffByMetric): Row[] {
   if (!assetsDiff) return [];
 
   const changedTypes = Object.keys(assetsDiff)
-    .filter(t => assetsDiff[t].minified.delta !== 0 || assetsDiff[t].gzip.delta !== 0)
+    .filter(t => hasMovedAssetDelta(assetsDiff[t]))
     .sort();
 
   if (changedTypes.length <= 1) return [];

--- a/packages/monosize/src/reporters/markdownReporter.mts
+++ b/packages/monosize/src/reporters/markdownReporter.mts
@@ -1,6 +1,6 @@
 import { getChangedEntriesInReport } from '../utils/getChangedEntriesInReport.mjs';
 import { formatBytes } from '../utils/helpers.mjs';
-import type { DiffByMetric } from '../utils/calculateDiff.mjs';
+import { hasMovedAssetDelta, type DiffByMetric } from '../utils/calculateDiff.mjs';
 import { formatDeltaFactory, type Reporter } from './shared.mjs';
 import { logger } from '../logger.mjs';
 
@@ -73,6 +73,47 @@ export const markdownReporter: Reporter = (report, options) => {
     });
 
     reportOutput.push('');
+
+    // Per-asset-type breakdown lives in its own section after the totals
+    // table — GFM tables can't span sub-rows, so interleaving <details>
+    // mid-table would break parsing. One <details> block per changed entry
+    // whose breakdown moved across more than one type — a single moved type
+    // would just duplicate the totals row, matching the cliReporter rule.
+    const entriesWithBreakdown = changedEntries.flatMap(entry => {
+      if (!entry.assetsDiff) {
+        return [];
+      }
+      const movedTypes = Object.keys(entry.assetsDiff)
+        .filter(t => hasMovedAssetDelta(entry.assetsDiff![t]))
+        .sort();
+      if (movedTypes.length <= 1) {
+        return [];
+      }
+      return [{ entry, movedTypes }];
+    });
+    const missingBreakdown = changedEntries.some(entry => !entry.assetsDiff && !entry.diff.empty);
+
+    if (entriesWithBreakdown.length > 0 || missingBreakdown) {
+      reportOutput.push('### Breakdown', '');
+
+      if (missingBreakdown) {
+        reportOutput.push(
+          '> Breakdown unavailable for some fixtures (remote report predates per-asset support — re-run measure on main to populate).',
+          '',
+        );
+      }
+
+      for (const { entry, movedTypes } of entriesWithBreakdown) {
+        reportOutput.push(`<details><summary><samp>${entry.packageName}</samp> · ${entry.name}</summary>`, '');
+        for (const type of movedTypes) {
+          const d = entry.assetsDiff![type];
+          reportOutput.push(
+            `- \`${type}\`: ${formatDelta(d.minified, deltaFormat)} minified, ${formatDelta(d.gzip, deltaFormat)} gzipped`,
+          );
+        }
+        reportOutput.push('</details>', '');
+      }
+    }
   }
 
   if (showUnchanged && unchangedEntries.length > 0) {

--- a/packages/monosize/src/reporters/markdownReporter.test.mts
+++ b/packages/monosize/src/reporters/markdownReporter.test.mts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import { reportWithExceededThreshold, sampleComparedReport } from '../__fixtures__/sampleComparedReport.mjs';
 import { logger } from '../logger.mjs';
 import { markdownReporter } from './markdownReporter.mjs';
+import type { ComparedReport } from '../utils/compareResultsInReports.mjs';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -50,6 +51,37 @@ describe('markdownReporter', () => {
     const output = await prettier.format(log.mock.calls[0][0] as string, { parser: 'markdown' });
 
     expect(output).toMatchSnapshot();
+  });
+
+  it('omits a Breakdown section when only a single asset type changed', async () => {
+    const log = vitest.spyOn(logger, 'raw').mockImplementation(noop);
+
+    const jsOnlyReport: ComparedReport = [
+      {
+        packageName: 'js-only-pkg',
+        name: 'JS-only entry',
+        path: 'js-only.fixture.js',
+        minifiedSize: 700,
+        gzippedSize: 70,
+        assets: { js: { minifiedSize: 700, gzippedSize: 70 } },
+        diff: {
+          empty: false,
+          exceedsThreshold: false,
+          minified: { delta: 700, percent: '100%' },
+          gzip: { delta: 70, percent: '100%' },
+        },
+        assetsDiff: {
+          js: { minified: { delta: 700, percent: '100%' }, gzip: { delta: 70, percent: '100%' } },
+        },
+      },
+    ];
+
+    markdownReporter(jsOnlyReport, { ...options, showUnchanged: false });
+    const output = await prettier.format(log.mock.calls[0][0] as string, { parser: 'markdown' });
+
+    // The single-type breakdown would just duplicate the totals row, so the
+    // section is suppressed (matches cliReporter).
+    expect(output).not.toContain('### Breakdown');
   });
 
   it('renders a report with exceeded threshold', async () => {

--- a/packages/monosize/src/utils/calculateDiff.mts
+++ b/packages/monosize/src/utils/calculateDiff.mts
@@ -89,6 +89,15 @@ export function calculateDiff(params: {
 }
 
 /**
+ * `true` when an asset type's diff has a non-zero minified or gzip delta.
+ * The single shared predicate used by reporters and the changed/unchanged
+ * splitter so they all agree on what "moved" means.
+ */
+export function hasMovedAssetDelta(diff: AssetDiff): boolean {
+  return diff.minified.delta !== 0 || diff.gzip.delta !== 0;
+}
+
+/**
  * Per-asset-type diff. Treats a missing side (asset only present in local
  * OR remote) as `{ minifiedSize: 0, gzippedSize: 0 }` — a brand-new type
  * surfaces as a positive delta, a removed type as a negative delta.

--- a/packages/monosize/src/utils/getChangedEntriesInReport.mts
+++ b/packages/monosize/src/utils/getChangedEntriesInReport.mts
@@ -1,3 +1,4 @@
+import { hasMovedAssetDelta } from './calculateDiff.mjs';
 import type { ComparedReport, ComparedReportEntry } from './compareResultsInReports.mjs';
 import { sortComparedReport } from './sortComparedReport.mjs';
 
@@ -15,7 +16,7 @@ function hasFlatAssetsBreakdown(entry: ComparedReportEntry): boolean {
     return true;
   }
 
-  return Object.values(entry.assetsDiff).every(d => d.minified.delta === 0 && d.gzip.delta === 0);
+  return !Object.values(entry.assetsDiff).some(hasMovedAssetDelta);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Markdown reporter now emits a post-table `### Breakdown` section with one `<details>` block per changed entry whose breakdown moved across more than one asset type. GFM tables can't span sub-rows, so interleaving `<details>` mid-table would break parsing — the section lives after the totals table instead.
- A single moved type would just duplicate the totals row, so the entry is omitted from the Breakdown section. This matches the cliReporter rule established in #199.
- Legacy fallback: when a changed entry has no `assetsDiff` (remote report predates the feature), the section surfaces a one-time legend ("Breakdown unavailable for some fixtures — re-run `measure` on main to populate"). Other entries in the same report still render their breakdown normally.
- The per-asset "did this delta move" check is hoisted into a single `hasMovedAssetDelta` predicate exported from `calculateDiff.mts` and used from `cliReporter`, `markdownReporter`, and `getChangedEntriesInReport.hasFlatAssetsBreakdown` so all three agree on what "moved" means.
- `Object.keys(assetsDiff)` iteration so future-version reports carrying unknown asset types (e.g. a stored `assets.svg`) still render rather than being silently dropped.

## Test plan

- [x] `yarn nx run-many --target=lint,build,test --all` — all tasks succeed
- [x] Existing `markdownReporter.test.mts` snapshots regenerated (multi-type fixtures unchanged in shape, just gain the new `### Breakdown` section)
- [x] New `markdownReporter` test: `omits a Breakdown section when only a single asset type changed` (asserts via `not.toContain('### Breakdown')`)
- [x] Beachball change file present (`type: none` — internal refactor / consumer-visible markdown surface, no separate release needed beyond the upstream feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
