### PR TITLE
test(e2e): rspack smoke covers measure + compare-reports pipeline

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -4,7 +4,7 @@
   "versionGroups": [
     {
       "label": "Local workspace cross-package deps are managed by beachball",
-      "dependencies": ["monosize", "monosize-bundler-*", "monosize-storage-*"],
+      "dependencies": ["monosize", "monosize-bundler-*", "monosize-storage-*", "monosize-smoke-*"],
       "isIgnored": true
     },
     {

--- a/change/monosize-c924df77-6eeb-4463-8006-4628d700152d.json
+++ b/change/monosize-c924df77-6eeb-4463-8006-4628d700152d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "internal: tighten buildAssetsDiff to skip when remote/local lacks assets",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/e2e/smoke-rspack/bundle-size/smoke.fixture.js
+++ b/e2e/smoke-rspack/bundle-size/smoke.fixture.js
@@ -1,0 +1,5 @@
+import { smoke } from 'monosize-smoke-rspack';
+
+console.log(smoke);
+
+export default { name: 'smoke' };

--- a/e2e/smoke-rspack/monosize.config.mjs
+++ b/e2e/smoke-rspack/monosize.config.mjs
@@ -1,0 +1,58 @@
+import createRspackBundler from 'monosize-bundler-rspack';
+
+/**
+ * Mock storage adapter — returns a "previous" report whose totals and
+ * per-asset breakdown are smaller than current so `compare-reports` shows
+ * a positive (regression) diff for both `js` and `css`, exercising the
+ * markdown breakdown section. `uploadReportToRemote` is a no-op; the
+ * smoke doesn't run that command.
+ *
+ * @type {import('monosize').StorageAdapter}
+ */
+const mockStorage = {
+  async getRemoteReport() {
+    return {
+      commitSHA: 'fake-baseline-sha',
+      remoteReport: [
+        {
+          // collectLocalReport prefers `project.json#name` over package.json
+          // when both exist, so use the project name to match the local entry.
+          packageName: 'smoke-rspack',
+          name: 'smoke',
+          path: 'bundle-size/smoke.fixture.js',
+          // Smaller-than-current sizes so the diff is positive (regression).
+          minifiedSize: 100,
+          gzippedSize: 50,
+          assets: {
+            js: { minifiedSize: 80, gzippedSize: 40 },
+            css: { minifiedSize: 20, gzippedSize: 10 },
+          },
+        },
+      ],
+    };
+  },
+  async uploadReportToRemote() {
+    /* no-op */
+  },
+};
+
+/** @type {import('monosize').MonoSizeConfig} */
+const config = {
+  repository: 'https://example.com/monosize-smoke-rspack',
+  // Default is `['js']`; opt in to `'css'` so the smoke covers a multi-asset report.
+  assetTypes: ['js', 'css'],
+  bundler: createRspackBundler(rsbuildConfig => {
+    // rsbuild inlines CSS into JS by default. Flip to emit a sidecar so
+    // the CLI's directory walk picks it up as a separate asset.
+    for (const env of Object.values(rsbuildConfig.environments ?? {})) {
+      env.output ??= {};
+      env.output.injectStyles = false;
+      env.output.distPath = { ...(env.output.distPath ?? {}), css: './' };
+      env.output.filename = { ...(env.output.filename ?? {}), css: '[name]/index.css' };
+    }
+    return rsbuildConfig;
+  }),
+  storage: mockStorage,
+};
+
+export default config;

--- a/e2e/smoke-rspack/package.json
+++ b/e2e/smoke-rspack/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "monosize-smoke-rspack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/smoke.js",
+  "dependencies": {
+    "monosize": "workspace:*",
+    "monosize-bundler-rspack": "workspace:*"
+  }
+}

--- a/e2e/smoke-rspack/project.json
+++ b/e2e/smoke-rspack/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "smoke-rspack",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/smoke-rspack",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "dependsOn": ["^build"],
+      "outputs": ["{workspaceRoot}/coverage/e2e/smoke-rspack"],
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/e2e/smoke-rspack/smoke.test.mts
+++ b/e2e/smoke-rspack/smoke.test.mts
@@ -1,0 +1,93 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import prettier from 'prettier';
+import { describe, it, expect } from 'vitest';
+import type { BundleSizeReport } from 'monosize';
+
+const execFileAsync = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const monosizeBin = path.join(repoRoot, 'packages', 'monosize', 'bin', 'monosize.mjs');
+
+async function runMonosize(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  // compare-reports exits with code 1 when threshold is exceeded — that's
+  // expected for the smoke (we deliberately set baseline sizes lower than
+  // current). Capture stdout/stderr regardless of exit code.
+  return execFileAsync(process.execPath, [monosizeBin, ...args], { cwd: here }).catch(err => {
+    if (err && typeof err === 'object' && 'stdout' in err) {
+      return { stdout: String(err.stdout ?? ''), stderr: String(err.stderr ?? '') };
+    }
+    throw err;
+  });
+}
+
+describe('rspack smoke', () => {
+  it('measure produces a report with both js and css assets', async () => {
+    await runMonosize(['measure', '--quiet']);
+
+    const reportPath = path.join(here, 'dist', 'bundle-size', 'monosize.json');
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8')) as BundleSizeReport;
+    const entry = report.find(e => e.name === 'smoke');
+    // Snapshot encodes the shape (entry present, both js + css measured) and
+    // the totals-equal-asset-sum invariant. Refresh with `vitest -u` if a
+    // bundler bump shifts byte counts.
+    expect(entry).toMatchInlineSnapshot(`
+      {
+        "assets": {
+          "css": {
+            "gzippedSize": 135,
+            "minifiedSize": 126,
+          },
+          "js": {
+            "gzippedSize": 179,
+            "minifiedSize": 236,
+          },
+        },
+        "gzippedSize": 314,
+        "minifiedSize": 362,
+        "name": "smoke",
+        "path": "bundle-size/smoke.fixture.js",
+      }
+    `);
+  });
+
+  it('compare-reports renders a per-asset breakdown', async () => {
+    // Depends on the report from the previous test; vitest runs `it` blocks
+    // in declaration order within a single file by default. Override the
+    // report-files glob since the smoke lives under e2e/, not packages/.
+    const { stdout } = await runMonosize([
+      'compare-reports',
+      '--output',
+      'markdown',
+      '--quiet',
+      // collectLocalReport globs from the git root by default, not the smoke's
+      // cwd, so point the glob at the smoke's own dist directory.
+      '--report-files-glob',
+      'e2e/smoke-rspack/dist/bundle-size/monosize.json',
+    ]);
+    const formatted = await prettier.format(stdout, { parser: 'markdown' });
+    expect(formatted).toMatchInlineSnapshot(`
+      "## 📊 Bundle size report
+
+      | Package & Exports                                                                                                 | Baseline (minified/GZIP) |                   PR |                                                                                                                                                                                                   Change |
+      | :---------------------------------------------------------------------------------------------------------------- | -----------------------: | -------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+      | <samp>smoke-rspack</samp> <br /> <abbr title='bundle-size/smoke.fixture.js'>smoke</abbr> <br /> ⚠️ over threshold |      \`100 B\`<br />\`50 B\` | \`362 B\`<br />\`314 B\` | \`262 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /><br />\`264 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> |
+
+      ### Breakdown
+
+      <details><summary><samp>smoke-rspack</samp> · smoke</summary>
+
+      - \`css\`: \`106 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`125 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+      - \`js\`: \`156 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> minified, \`139 B\` <img aria-hidden="true" src="https://microsoft.github.io/monosize/images/increase.png" /> gzipped
+      </details>
+
+      <sub>🤖 This report was generated against <a href='https://example.com/monosize-smoke-rspack/commit/fake-baseline-sha'>fake-baseline-sha</a></sub>
+      "
+    `);
+  });
+});

--- a/e2e/smoke-rspack/src/smoke.js
+++ b/e2e/smoke-rspack/src/smoke.js
@@ -1,0 +1,13 @@
+import classes from './smoke.module.css';
+
+export function smoke() {
+  const root = document.createElement('div');
+  root.className = classes.card;
+
+  const title = document.createElement('span');
+  title.className = classes.cardTitle;
+  title.textContent = 'Smoke';
+  root.append(title);
+
+  document.body.append(root);
+}

--- a/e2e/smoke-rspack/src/smoke.module.css
+++ b/e2e/smoke-rspack/src/smoke.module.css
@@ -1,0 +1,11 @@
+.card {
+  color: rebeccapurple;
+  padding: 1rem;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+}
+
+.cardTitle {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}

--- a/e2e/smoke-rspack/tsconfig.json
+++ b/e2e/smoke-rspack/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["**/*.mts", "**/*.mjs"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    {
+      "path": "../../packages/monosize"
+    },
+    {
+      "path": "../../packages/monosize-bundler-rspack"
+    }
+  ]
+}

--- a/e2e/smoke-rspack/vite.config.mts
+++ b/e2e/smoke-rspack/vite.config.mts
@@ -1,0 +1,18 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/smoke-rspack',
+
+  resolve: {
+    conditions: ['@monosize/source'],
+  },
+
+  test: {
+    reporters: ['default'],
+    include: ['**/*.test.mts'],
+    // Real bundler builds + subprocess invocations are slow.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "e2e/*"
   ],
   "license": "MIT",
   "repository": {

--- a/packages/monosize/src/utils/compareResultsInReports.mts
+++ b/packages/monosize/src/utils/compareResultsInReports.mts
@@ -21,14 +21,19 @@ function buildAssetsDiff(
   localAssets: BundleSizeReportEntry['assets'],
   remoteAssets: BundleSizeReportEntry['assets'],
 ): Record<string, AssetDiff> | undefined {
-  if (!localAssets && !remoteAssets) {
+  // Both sides must carry `assets` for a meaningful per-type comparison.
+  // When either side is missing (typically: remote was written before the
+  // assets field existed), suppress assetsDiff so reporters can render the
+  // "breakdown unavailable" legend instead of presenting a fabricated diff
+  // against an unknown baseline.
+  if (!localAssets || !remoteAssets) {
     return undefined;
   }
 
   // Widen the index signature to `string` so unknown future asset types
   // (e.g. a stored `assets.svg`) flow through without a cast at the call site.
-  const local: Record<string, AssetSize | undefined> = localAssets ?? {};
-  const remote: Record<string, AssetSize | undefined> = remoteAssets ?? {};
+  const local: Record<string, AssetSize | undefined> = localAssets;
+  const remote: Record<string, AssetSize | undefined> = remoteAssets;
   const types = [...new Set([...Object.keys(local), ...Object.keys(remote)])].sort();
 
   return Object.fromEntries(types.map(type => [type, calculateAssetDiff(local[type], remote[type])]));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,29 @@
   "files": [],
   "include": [],
   "references": [
-    { "path": "./packages/monosize" },
-    { "path": "./packages/monosize-bundler-rspack" },
-    { "path": "./packages/monosize-bundler-vite" },
-    { "path": "./packages/monosize-bundler-webpack" },
-    { "path": "./packages/monosize-storage-git" },
-    { "path": "./packages/monosize-storage-upstash" },
-    { "path": "./typings" }
+    {
+      "path": "./packages/monosize"
+    },
+    {
+      "path": "./packages/monosize-bundler-rspack"
+    },
+    {
+      "path": "./packages/monosize-bundler-vite"
+    },
+    {
+      "path": "./packages/monosize-bundler-webpack"
+    },
+    {
+      "path": "./packages/monosize-storage-git"
+    },
+    {
+      "path": "./packages/monosize-storage-upstash"
+    },
+    {
+      "path": "./typings"
+    },
+    {
+      "path": "./e2e/smoke-rspack"
+    }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6123,7 +6123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monosize-bundler-rspack@workspace:packages/monosize-bundler-rspack":
+"monosize-bundler-rspack@workspace:*, monosize-bundler-rspack@workspace:packages/monosize-bundler-rspack":
   version: 0.0.0-use.local
   resolution: "monosize-bundler-rspack@workspace:packages/monosize-bundler-rspack"
   dependencies:
@@ -6203,6 +6203,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"monosize-smoke-rspack@workspace:e2e/smoke-rspack":
+  version: 0.0.0-use.local
+  resolution: "monosize-smoke-rspack@workspace:e2e/smoke-rspack"
+  dependencies:
+    monosize: "workspace:*"
+    monosize-bundler-rspack: "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "monosize-storage-git@workspace:packages/monosize-storage-git":
   version: 0.0.0-use.local
   resolution: "monosize-storage-git@workspace:packages/monosize-storage-git"
@@ -6224,7 +6233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"monosize@npm:^0.8.3, monosize@workspace:packages/monosize":
+"monosize@npm:^0.8.3, monosize@workspace:*, monosize@workspace:packages/monosize":
   version: 0.0.0-use.local
   resolution: "monosize@workspace:packages/monosize"
   dependencies:


### PR DESCRIPTION
## Summary

End-to-end smoke that exercises the full `measure` → `compare-reports` pipeline against the rspack adapter, with both JS and CSS assets emitted.

- New workspace package `monosize-smoke-rspack` under `e2e/smoke-rspack/`. Source in `src/smoke.js` + `src/smoke.module.css`; the bundle-size fixture is a thin consumer (`import { smoke } from 'monosize-smoke-rspack'`), so workspace resolution does the path work — no aliases or `originalFixturesDir` glue.
- `monosize.config.mjs` opts in to `assetTypes: ['js', 'css']` and flips rsbuild's default `injectStyles` so CSS lands as a sidecar in `<outputDir>/index.css` next to `index.js`. `mockStorage` returns a baseline with smaller per-asset sizes (js 80/40 + css 20/10 = 100/50 totals) so `compare-reports` shows a positive delta on both types.
- `smoke.test.mts` runs the real `monosize` CLI via `execFile` and asserts on:
  1. `measure` — the produced report entry shape (`toMatchInlineSnapshot`, byte counts captured from a green run; refresh with `vitest -u` after a bundler bump)
  2. `compare-reports --output markdown --quiet` — stdout piped through `prettier.format(parser: 'markdown')` and snapshotted, covering the totals row + `### Breakdown` `<details>` block + `js`/`css` deltas + footer
- `project.json#test.dependsOn: ["^build"]` — `monosize:build` runs before the smoke fires; no manual `dist`-exists `beforeAll` guard.
- `tsconfig.json` references `./e2e/smoke-rspack` so the smoke participates in the project graph.
- `compareResultsInReports.buildAssetsDiff` rebase: kept #199's structural cleanup (`Object.fromEntries` + `string`-widened index) AND added a semantic outer guard — when either side lacks `assets`, return `undefined` instead of fabricating a zero-baseline diff against an unknown remote.
- `.syncpackrc.json`: ignore the `monosize-smoke-*` workspace package family alongside `monosize-bundler-*` / `monosize-storage-*` so the smoke's `0.0.0` version doesn't trip `DependsOnMissingSnapTarget`.
- `monosize` change file (`type: none`) for the `buildAssetsDiff` semantic tighten.

## Test plan

- [x] `yarn nx run-many --target=lint,build,test --all` — all 19 tasks succeed
- [x] `yarn check-dependencies` clean (after the `monosize-smoke-*` ignore)
- [x] `yarn beachball check` clean (existing `monosize` change files plus the new `none` entry)
- [x] `yarn nx run smoke-rspack:test` runs `monosize:build` first via `dependsOn` and both inline snapshots match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
