### PR TITLE
chore: add logger.warn + fix types in collectLocalReport

### DIFF
--- a/change/monosize-42120029-1e80-4fc3-9e50-90bd70c83010.json
+++ b/change/monosize-42120029-1e80-4fc3-9e50-90bd70c83010.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add logger.warn + fix collectLocalReport types",
+  "packageName": "monosize",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/monosize/src/logger.mts
+++ b/packages/monosize/src/logger.mts
@@ -4,7 +4,7 @@ import { styleText } from 'node:util';
 import { formatHrTime } from './utils/helpers.mjs';
 
 type LogFunction = (message: unknown, timestamp?: ReturnType<typeof process.hrtime>) => void;
-type LogTypes = 'error' | 'info' | 'success' | 'finish';
+type LogTypes = 'error' | 'info' | 'success' | 'warn' | 'finish';
 
 export const timestamp = (): ReturnType<typeof process.hrtime> => process.hrtime();
 
@@ -34,6 +34,9 @@ export const logger: Record<LogTypes, LogFunction> & { raw: (...args: unknown[])
   },
   success: (message, time) => {
     console.log(styleText('green', '[✔]'), message, toFriendlyTime(time));
+  },
+  warn: (message, time) => {
+    console.warn(styleText('yellow', '[!]'), message, toFriendlyTime(time));
   },
 
   // Special logging for the end of the process

--- a/packages/monosize/src/utils/collectLocalReport.mts
+++ b/packages/monosize/src/utils/collectLocalReport.mts
@@ -4,7 +4,10 @@ import { execSync } from 'node:child_process';
 import { any as findUp } from 'empathic/find';
 import { glob } from 'tinyglobby';
 
-import type { BuildResult, BundleSizeReport, MonoSizeConfig } from '../types.mjs';
+import type { BundleSizeReport, BundleSizeReportEntry, MonoSizeConfig } from '../types.mjs';
+
+/** Shape of one entry as it sits on disk in `monosize.json` — no `packageName` (added in this module). */
+type StoredReportEntry = Omit<BundleSizeReportEntry, 'packageName'>;
 
 type CollectLocalReportOptions = {
   root: string | undefined;
@@ -68,12 +71,12 @@ async function getPackageName(packageRoot: string): Promise<string> {
 async function readReportForPackage(
   reportFile: string,
   resolvers: ReportResolvers,
-): Promise<{ packageName: string; packageReport: BuildResult[] }> {
+): Promise<{ packageName: string; packageReport: StoredReportEntry[] }> {
   const packageRoot = await resolvers.packageRoot(reportFile);
   const packageName = await resolvers.packageName(packageRoot);
 
   try {
-    const packageReport: BuildResult[] = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
+    const packageReport: StoredReportEntry[] = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
 
     return { packageName, packageReport };
   } catch (e) {


### PR DESCRIPTION
Pre-work extracted from the [#172](https://github.com/microsoft/monosize/issues/172) stack so the contract-switch PR ([#198](https://github.com/microsoft/monosize/pull/198)) stays focused on the BundlerAdapter change.

## Summary

- **\`logger\` gains a \`warn\` method.** Yellow \`[!]\` prefix; mirrors the existing \`error\`/\`info\`/\`success\` shape. Used by upcoming \`measure\` changes (allowlist misconfiguration warning) but useful on its own.
- **\`collectLocalReport.readReportForPackage\` type drift fix.** Was typed \`packageReport: BuildResult[]\`; the on-disk \`monosize.json\` shape is broader (carries \`packageName\` when re-emitted, and after #197 may carry the optional \`assets\` field). Switch to \`Omit<BundleSizeReportEntry, 'packageName'>\` which matches the actual stored shape. Type-only; runtime behavior unchanged.

## Test plan
- [x] yarn build && yarn test pass for monosize
- [x] No behavior change for any caller; new \`warn\` has no current consumer in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)