### PR TITLE
chore: drop patch bumps from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       - dependency-name: 'nx'
       - dependency-name: '@nx/*'
       - dependency-name: 'typescript'
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-patch'
     groups:
       eslint:
         patterns:
@@ -22,7 +25,7 @@ updates:
         patterns:
           - 'vitest'
           - '@vitest/*'
-      dev-minor-patch:
+      dev-minor:
         dependency-type: development
         update-types:
           - minor
@@ -33,8 +36,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-patch'
     groups:
-      actions-minor-patch:
+      actions-minor:
         update-types:
           - minor
-          - patch


### PR DESCRIPTION
## Summary

Stops Dependabot from opening PRs for patch-level updates. Patches add noise without meaningfully changing risk posture; they ride to the next minor/major. Mirrors the pattern used in [microsoft/griffel](https://github.com/microsoft/griffel/blob/main/.github/dependabot.yml).

- Add `'*'` / `version-update:semver-patch` to the ignore list for both the `npm` and `github-actions` ecosystems.
- Rename `dev-minor-patch` → `dev-minor` and `actions-minor-patch` → `actions-minor`; drop `patch` from the actions group's `update-types`.

## Test plan

- [x] Config validates as YAML
- [ ] Verify in-flight Dependabot runs respect the new ignore (will become observable after merge on the next scheduled run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)