### PR TITLE
fix(storage-git): skip artifacts that don't match the expected shape

### DIFF
--- a/change/monosize-storage-git-dd6214ee-fd36-4886-8b2b-54598de6d5e2.json
+++ b/change/monosize-storage-git-dd6214ee-fd36-4886-8b2b-54598de6d5e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: skip artifacts whose JSON shape is not the expected `{ commitSHA, data }` wrapper, instead of returning `remoteReport: undefined`",
+  "packageName": "monosize-storage-git",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize-storage-git/src/index.mts
+++ b/packages/monosize-storage-git/src/index.mts
@@ -23,6 +23,15 @@ type StoredReport = {
   data: BundleSizeReport;
 };
 
+function isStoredReport(value: unknown): value is StoredReport {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as StoredReport).commitSHA === 'string' &&
+    Array.isArray((value as StoredReport).data)
+  );
+}
+
 const DEFAULT_ARTIFACT_NAME = 'monosize-report';
 
 function createGitStorage(config: GitStorageConfig): StorageAdapter {
@@ -79,7 +88,15 @@ function createGitStorage(config: GitStorageConfig): StorageAdapter {
         continue;
       }
 
-      const report: StoredReport = JSON.parse(entry.getData().toString('utf-8'));
+      const report: unknown = JSON.parse(entry.getData().toString('utf-8'));
+
+      if (!isStoredReport(report)) {
+        console.warn(
+          `monosize-storage-git: artifact "${artifactName}" in run ${run.id} has unexpected shape ` +
+            `(expected { commitSHA, data: [...] }). Skipping.`,
+        );
+        continue;
+      }
 
       return {
         commitSHA: report.commitSHA,

--- a/packages/monosize-storage-git/src/index.test.mts
+++ b/packages/monosize-storage-git/src/index.test.mts
@@ -144,6 +144,66 @@ describe('createGitStorage', () => {
       expect(result.remoteReport).toEqual([]);
     });
 
+    it('skips malformed artifacts (raw report array) and falls through to next run', async () => {
+      // Repro for the historical keyborg failure: an older base workflow
+      // uploaded `dist/bundle-size/monosize.json` (a raw `BundleSizeReport`
+      // array) directly, instead of the `{ commitSHA, data }` wrapper that
+      // `upload-report` writes. Adapter must not return that as
+      // `remoteReport: undefined` — otherwise downstream `.find()` crashes.
+      const storage = createGitStorage({ owner: 'microsoft', repo: 'monosize', workflowFileName: 'ci.yml', outputPath: 'dist/report.json', artifactName: 'monosize-report' });
+      const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      mockListWorkflowRuns.mockResolvedValue({
+        data: {
+          workflow_runs: [
+            { id: 100, head_sha: 'old-shape' },
+            { id: 101, head_sha: 'new-shape' },
+          ],
+        },
+      });
+      mockListWorkflowRunArtifacts.mockResolvedValue({
+        data: { artifacts: [{ id: 200, name: 'monosize-report' }] },
+      });
+      mockDownloadArtifact
+        // First run: raw array (legacy upload).
+        .mockResolvedValueOnce({ data: createZip('report.json', JSON.stringify(sampleReport)) })
+        // Second run: properly wrapped.
+        .mockResolvedValueOnce({
+          data: createZip('report.json', JSON.stringify({ commitSHA: 'new-shape', data: sampleReport })),
+        });
+
+      const result = await storage.getRemoteReport('main');
+
+      expect(result.commitSHA).toBe('new-shape');
+      expect(result.remoteReport).toEqual(sampleReport);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unexpected shape'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('returns empty report when all runs have malformed artifacts', async () => {
+      const storage = createGitStorage({ owner: 'microsoft', repo: 'monosize', workflowFileName: 'ci.yml', outputPath: 'dist/report.json', artifactName: 'monosize-report' });
+      const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      mockListWorkflowRuns.mockResolvedValue({
+        data: { workflow_runs: [{ id: 100, head_sha: 'old-shape' }] },
+      });
+      mockListWorkflowRunArtifacts.mockResolvedValue({
+        data: { artifacts: [{ id: 200, name: 'monosize-report' }] },
+      });
+      mockDownloadArtifact.mockResolvedValue({
+        data: createZip('report.json', JSON.stringify(sampleReport)),
+      });
+
+      const result = await storage.getRemoteReport('main');
+
+      expect(result.commitSHA).toBe('');
+      expect(result.remoteReport).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      warnSpy.mockRestore();
+    });
+
     it('throws when GITHUB_TOKEN is not set', async () => {
       delete process.env['GITHUB_TOKEN'];
       const storage = createGitStorage({ owner: 'microsoft', repo: 'monosize', workflowFileName: 'ci.yml', outputPath: 'dist/report.json', artifactName: 'monosize-report' });


### PR DESCRIPTION
## Summary

A workflow artifact whose JSON isn't the expected `{ commitSHA, data: [...] }` wrapper (the shape `monosize upload-report` writes) currently makes `getRemoteReport` return `remoteReport: undefined` — which crashes `compareResultsInReports` downstream with a cryptic `TypeError: Cannot read properties of undefined (reading 'find')`.

This was real: it bit [microsoft/keyborg#22954744131](https://github.com/microsoft/keyborg/actions/runs/22954744131/job/66628308938) when the base workflow on `main` was still uploading `dist/bundle-size/monosize.json` directly (a raw `BundleSizeReport` array) while a PR was already on a newer adapter version that expected the wrapper. The adapter parsed the array, read `report.data` → `undefined`, and silently propagated it.

- Add an `isStoredReport` shape check before returning. If the artifact JSON isn't `{ commitSHA: string, data: BundleSizeReport }`, log a `console.warn` naming the run id + artifact name and `continue` to the next run — same fall-through behavior as "no artifact found".
- Two new tests: (a) a malformed artifact in run N falls through to a well-formed artifact in run N+1; (b) all-malformed artifacts return the empty `{ commitSHA: '', remoteReport: [] }` baseline (and warn once per run).
- Patch change file for `monosize-storage-git`.

No CLI-side guard — the contract violation is an adapter concern; storage adapters are responsible for returning the documented shape.

## Test plan

- [x] `yarn nx run monosize-storage-git:test` — 9 tests pass (2 new)
- [x] `yarn nx run monosize-storage-git:lint` — clean
- [x] `yarn beachball check` — clean (new patch change file picked up)
- [x] `yarn check-dependencies` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)