### PR TITLE
feat(monosize): evaluate compare-reports threshold per package

### DIFF
--- a/change/monosize-local-threshold.json
+++ b/change/monosize-local-threshold.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: evaluate compare-reports threshold per package by capturing the resolved threshold during measure",
+  "packageName": "monosize",
+  "email": "hochelmartin@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/monosize/src/commands/compareReports.mts
+++ b/packages/monosize/src/commands/compareReports.mts
@@ -24,7 +24,10 @@ async function compareReports(options: CompareReportsOptions) {
   const startTime = timestamp();
 
   const config = await readConfig(quiet);
-  const threshold = parseThreshold(config.threshold ?? DEFAULT_THRESHOLD);
+  // Root/default threshold; used as a fallback for entries whose report did
+  // not capture a threshold at `measure` time. Per-package thresholds stamped
+  // onto entries take precedence in `compareResultsInReports`.
+  const fallbackThreshold = parseThreshold(config.threshold ?? DEFAULT_THRESHOLD);
 
   const localReportStartTime = timestamp();
   const localReport = await collectLocalReport({
@@ -47,7 +50,7 @@ async function compareReports(options: CompareReportsOptions) {
     }
   }
 
-  const reportsComparisonResult = compareResultsInReports(localReport, remoteReport, threshold);
+  const reportsComparisonResult = compareResultsInReports(localReport, remoteReport, fallbackThreshold);
 
   switch (output) {
     case 'cli':

--- a/packages/monosize/src/commands/measure.mts
+++ b/packages/monosize/src/commands/measure.mts
@@ -225,12 +225,11 @@ async function measure(options: MeasureOptions) {
 
   const config = await readConfig(quiet);
 
-  // Validate the configured threshold eagerly so a malformed value fails
-  // `measure` (where the config lives) rather than surfacing later in
-  // `compare-reports`, which consumes the value stamped onto each entry.
-  if (config.threshold !== undefined) {
-    parseThreshold(config.threshold);
-  }
+  // Parse the configured threshold once, here where the config lives, so a
+  // malformed value fails `measure` rather than surfacing later in
+  // `compare-reports`. The parsed value is stamped onto each entry below, so
+  // `compare-reports` consumes it directly without re-parsing.
+  const threshold = config.threshold === undefined ? undefined : parseThreshold(config.threshold);
 
   if (!quiet) {
     logger.info(`Measuring bundle size for ${fixtures.length} fixture(s)...`);
@@ -252,9 +251,9 @@ async function measure(options: MeasureOptions) {
   // non-override packages inherit the nearest (root) config's threshold.
   // Left unset only when no threshold is configured anywhere; the default
   // is then applied by `compare-reports`.
-  if (config.threshold !== undefined) {
+  if (threshold !== undefined) {
     for (const measurement of measurements) {
-      measurement.threshold = config.threshold;
+      measurement.threshold = threshold;
     }
   }
 

--- a/packages/monosize/src/commands/measure.mts
+++ b/packages/monosize/src/commands/measure.mts
@@ -5,7 +5,7 @@ import { glob } from 'tinyglobby';
 import path from 'node:path';
 import type { CommandModule } from 'yargs';
 
-import { formatBytes } from '../utils/helpers.mjs';
+import { formatBytes, parseThreshold } from '../utils/helpers.mjs';
 import { prepareFixture } from '../utils/prepareFixture.mjs';
 import { readConfig } from '../utils/readConfig.mjs';
 import type { CliOptions } from '../index.mjs';
@@ -225,6 +225,13 @@ async function measure(options: MeasureOptions) {
 
   const config = await readConfig(quiet);
 
+  // Validate the configured threshold eagerly so a malformed value fails
+  // `measure` (where the config lives) rather than surfacing later in
+  // `compare-reports`, which consumes the value stamped onto each entry.
+  if (config.threshold !== undefined) {
+    parseThreshold(config.threshold);
+  }
+
   if (!quiet) {
     logger.info(`Measuring bundle size for ${fixtures.length} fixture(s)...`);
     logger.raw(fixtures.map(fixture => `  - ${fixture}`).join('\n'));
@@ -238,6 +245,18 @@ async function measure(options: MeasureOptions) {
     buildMode === 'batch'
       ? await buildFixturesInBatchMode(config, fixtures, artifactsDir, debug, quiet)
       : await buildFixturesInSequentialMode(config, fixtures, artifactsDir, debug, quiet);
+
+  // Stamp the resolved threshold onto every entry so the report is
+  // self-describing and `compare-reports` can gate each package on its own
+  // config. Emitted for all packages since `measure` runs per package and
+  // non-override packages inherit the nearest (root) config's threshold.
+  // Left unset only when no threshold is configured anywhere; the default
+  // is then applied by `compare-reports`.
+  if (config.threshold !== undefined) {
+    for (const measurement of measurements) {
+      measurement.threshold = config.threshold;
+    }
+  }
 
   measurements.sort((a, b) => a.path.localeCompare(b.path, 'en'));
 

--- a/packages/monosize/src/commands/measure.test.mts
+++ b/packages/monosize/src/commands/measure.test.mts
@@ -5,6 +5,7 @@ import { gzipSync } from 'node:zlib';
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import api, { type MeasureOptions } from './measure.mjs';
 import { logger } from '../logger.mjs';
+import { readConfig } from '../utils/readConfig.mjs';
 
 /**
  * Materializes an `outputDir` next to the prepared fixture and writes the
@@ -249,6 +250,46 @@ describe('measure', () => {
       const report = JSON.parse(fs.readFileSync(path.resolve(packageDir, 'output', 'monosize.json'), 'utf-8'));
       const entry = report[0];
       expect(Object.keys(entry.assets).sort()).toEqual(['js', 'json']);
+    });
+  });
+
+  describe('threshold', () => {
+    /** Provides a one-off config carrying a `threshold`, reusing the synthetic bundler. */
+    function withConfigThreshold(threshold: string) {
+      vitest.mocked(readConfig).mockResolvedValueOnce({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        bundler: { name: 'fake', buildFixtures } as any,
+        assetTypes: ['css', 'js', 'json'],
+        threshold,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    }
+
+    it('stamps the configured threshold onto every entry', async () => {
+      withConfigThreshold('5 kB');
+      const { packageDir } = await setup(getMockedFixtures('foo', 'bar'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await api.handler(baseOptions() as any);
+
+      const report = JSON.parse(fs.readFileSync(path.resolve(packageDir, 'output', 'monosize.json'), 'utf-8'));
+      expect(report.map((entry: { threshold?: string }) => entry.threshold)).toEqual(['5 kB', '5 kB']);
+    });
+
+    it('omits the threshold field when none is configured', async () => {
+      const { packageDir } = await setup(getMockedFixtures('foo'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await api.handler(baseOptions() as any);
+
+      const report = JSON.parse(fs.readFileSync(path.resolve(packageDir, 'output', 'monosize.json'), 'utf-8'));
+      expect(report[0]).not.toHaveProperty('threshold');
+    });
+
+    it('fails measure when the configured threshold is malformed', async () => {
+      withConfigThreshold('not-a-threshold');
+      await setup(getMockedFixtures('foo'));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await expect(api.handler(baseOptions() as any)).rejects.toThrow(/Invalid threshold value/);
     });
   });
 });

--- a/packages/monosize/src/commands/measure.test.mts
+++ b/packages/monosize/src/commands/measure.test.mts
@@ -265,14 +265,17 @@ describe('measure', () => {
       } as any);
     }
 
-    it('stamps the configured threshold onto every entry', async () => {
+    it('stamps the parsed threshold onto every entry', async () => {
       withConfigThreshold('5 kB');
       const { packageDir } = await setup(getMockedFixtures('foo', 'bar'));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await api.handler(baseOptions() as any);
 
       const report = JSON.parse(fs.readFileSync(path.resolve(packageDir, 'output', 'monosize.json'), 'utf-8'));
-      expect(report.map((entry: { threshold?: string }) => entry.threshold)).toEqual(['5 kB', '5 kB']);
+      expect(report.map((entry: { threshold?: unknown }) => entry.threshold)).toEqual([
+        { size: 5120, type: 'size' },
+        { size: 5120, type: 'size' },
+      ]);
     });
 
     it('omits the threshold field when none is configured', async () => {

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -24,6 +24,16 @@ export type BundleSizeReportEntry = Pick<BuildResult, 'name' | 'path' | 'minifie
    * returned from storage written before this change.
    */
   assets?: Partial<Record<AssetType, AssetSize>>;
+  /**
+   * The threshold (e.g. `'5 kB'`, `'10%'`) resolved from the nearest
+   * `monosize.config` at `measure` time and captured per entry. Because
+   * `measure` runs per package, this reflects that package's own config
+   * (or the inherited root config). `compare-reports` gates each entry on
+   * its own value, falling back to the root/default threshold when absent
+   * (no threshold configured anywhere, or a legacy report written before
+   * this field existed).
+   */
+  threshold?: string;
 };
 export type BundleSizeReport = BundleSizeReportEntry[];
 

--- a/packages/monosize/src/types.mts
+++ b/packages/monosize/src/types.mts
@@ -25,15 +25,15 @@ export type BundleSizeReportEntry = Pick<BuildResult, 'name' | 'path' | 'minifie
    */
   assets?: Partial<Record<AssetType, AssetSize>>;
   /**
-   * The threshold (e.g. `'5 kB'`, `'10%'`) resolved from the nearest
-   * `monosize.config` at `measure` time and captured per entry. Because
-   * `measure` runs per package, this reflects that package's own config
-   * (or the inherited root config). `compare-reports` gates each entry on
-   * its own value, falling back to the root/default threshold when absent
-   * (no threshold configured anywhere, or a legacy report written before
-   * this field existed).
+   * The threshold resolved from the nearest `monosize.config` at `measure`
+   * time and captured per entry, already parsed to its structured form.
+   * Because `measure` runs per package, this reflects that package's own
+   * config (or the inherited root config). `compare-reports` gates each entry
+   * on its own value, falling back to the root/default threshold when absent
+   * (no threshold configured anywhere, or a legacy report written before this
+   * field existed).
    */
-  threshold?: string;
+  threshold?: ThresholdValue;
 };
 export type BundleSizeReport = BundleSizeReportEntry[];
 

--- a/packages/monosize/src/utils/compareResultsInReports.mts
+++ b/packages/monosize/src/utils/compareResultsInReports.mts
@@ -1,5 +1,4 @@
 import { calculateAssetDiff, calculateDiff, EMPTY_DIFF, type AssetDiff, type DiffForEntry } from './calculateDiff.mjs';
-import { parseThreshold } from './helpers.mjs';
 import type { AssetSize, BundleSizeReport, BundleSizeReportEntry, ThresholdValue } from '../types.mjs';
 
 export type ComparedReportEntry = BundleSizeReportEntry & {
@@ -45,28 +44,6 @@ export function compareResultsInReports(
   remoteReport: BundleSizeReport,
   fallbackThreshold: ThresholdValue,
 ): ComparedReport {
-  // Each entry is gated on the threshold captured at `measure` time (its own
-  // package's config). `fallbackThreshold` (root/default) applies only when an
-  // entry carries no threshold — nothing configured anywhere, or a legacy
-  // report. A malformed value throws (surfacing corruption) rather than being
-  // silently swapped for the fallback; `measure` validates on write, so any
-  // report produced by monosize holds a parseable value here.
-  const thresholdCache = new Map<string, ThresholdValue>();
-  const resolveThreshold = (raw: string | undefined): ThresholdValue => {
-    if (raw === undefined) {
-      return fallbackThreshold;
-    }
-
-    const cached = thresholdCache.get(raw);
-    if (cached) {
-      return cached;
-    }
-
-    const resolved = parseThreshold(raw);
-    thresholdCache.set(raw, resolved);
-    return resolved;
-  };
-
   return localReport.map(localEntry => {
     const remoteEntry = remoteReport.find(
       entry => localEntry.packageName === entry.packageName && localEntry.path === entry.path,
@@ -80,7 +57,11 @@ export function compareResultsInReports(
         diff: calculateDiff({
           localEntry,
           remoteEntry,
-          threshold: resolveThreshold(localEntry.threshold),
+          // Each entry is gated on the threshold captured at `measure` time
+          // (its own package's config). `fallbackThreshold` (root/default)
+          // applies only when an entry carries no threshold — nothing
+          // configured anywhere, or a legacy report.
+          threshold: localEntry.threshold ?? fallbackThreshold,
         }),
         ...(assetsDiff && { assetsDiff }),
       };

--- a/packages/monosize/src/utils/compareResultsInReports.mts
+++ b/packages/monosize/src/utils/compareResultsInReports.mts
@@ -1,4 +1,5 @@
 import { calculateAssetDiff, calculateDiff, EMPTY_DIFF, type AssetDiff, type DiffForEntry } from './calculateDiff.mjs';
+import { parseThreshold } from './helpers.mjs';
 import type { AssetSize, BundleSizeReport, BundleSizeReportEntry, ThresholdValue } from '../types.mjs';
 
 export type ComparedReportEntry = BundleSizeReportEntry & {
@@ -42,8 +43,30 @@ function buildAssetsDiff(
 export function compareResultsInReports(
   localReport: BundleSizeReport,
   remoteReport: BundleSizeReport,
-  threshold: ThresholdValue,
+  fallbackThreshold: ThresholdValue,
 ): ComparedReport {
+  // Each entry is gated on the threshold captured at `measure` time (its own
+  // package's config). `fallbackThreshold` (root/default) applies only when an
+  // entry carries no threshold — nothing configured anywhere, or a legacy
+  // report. A malformed value throws (surfacing corruption) rather than being
+  // silently swapped for the fallback; `measure` validates on write, so any
+  // report produced by monosize holds a parseable value here.
+  const thresholdCache = new Map<string, ThresholdValue>();
+  const resolveThreshold = (raw: string | undefined): ThresholdValue => {
+    if (raw === undefined) {
+      return fallbackThreshold;
+    }
+
+    const cached = thresholdCache.get(raw);
+    if (cached) {
+      return cached;
+    }
+
+    const resolved = parseThreshold(raw);
+    thresholdCache.set(raw, resolved);
+    return resolved;
+  };
+
   return localReport.map(localEntry => {
     const remoteEntry = remoteReport.find(
       entry => localEntry.packageName === entry.packageName && localEntry.path === entry.path,
@@ -57,7 +80,7 @@ export function compareResultsInReports(
         diff: calculateDiff({
           localEntry,
           remoteEntry,
-          threshold,
+          threshold: resolveThreshold(localEntry.threshold),
         }),
         ...(assetsDiff && { assetsDiff }),
       };

--- a/packages/monosize/src/utils/compareResultsInReports.test.mts
+++ b/packages/monosize/src/utils/compareResultsInReports.test.mts
@@ -87,4 +87,43 @@ describe('compareResultsInReports', () => {
       }
     `);
   });
+
+  it('gates each entry on its own captured threshold, falling back per entry', () => {
+    // `one` grew 3 kB and carries a strict `2 kB` threshold -> exceeds.
+    // `two` grew the same 3 kB but carries a lax `5 kB` threshold -> within.
+    // `three` carries no threshold and relies on the passed fallback (2 kB) -> exceeds.
+    const localReport: BundleSizeReport = [
+      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 4072, gzippedSize: 500, threshold: '2 kB' },
+      { packageName: 'two', name: 'two', path: 'two.js', minifiedSize: 4072, gzippedSize: 500, threshold: '5 kB' },
+      { packageName: 'three', name: 'three', path: 'three.js', minifiedSize: 4072, gzippedSize: 500 },
+    ];
+    const remoteReport: BundleSizeReport = [
+      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 1000, gzippedSize: 100 },
+      { packageName: 'two', name: 'two', path: 'two.js', minifiedSize: 1000, gzippedSize: 100 },
+      { packageName: 'three', name: 'three', path: 'three.js', minifiedSize: 1000, gzippedSize: 100 },
+    ];
+    const fallbackThreshold = { size: 2048, type: 'size' } as const;
+
+    const actual = compareResultsInReports(localReport, remoteReport, fallbackThreshold);
+
+    expect(actual.map(entry => [entry.packageName, entry.diff.exceedsThreshold])).toEqual([
+      ['one', true],
+      ['two', false],
+      ['three', true],
+    ]);
+  });
+
+  it('throws when a captured threshold is malformed', () => {
+    const localReport: BundleSizeReport = [
+      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 4072, gzippedSize: 500, threshold: 'nonsense' },
+    ];
+    const remoteReport: BundleSizeReport = [
+      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 1000, gzippedSize: 100 },
+    ];
+    const fallbackThreshold = { size: 2048, type: 'size' } as const;
+
+    expect(() => compareResultsInReports(localReport, remoteReport, fallbackThreshold)).toThrow(
+      /Invalid threshold value/,
+    );
+  });
 });

--- a/packages/monosize/src/utils/compareResultsInReports.test.mts
+++ b/packages/monosize/src/utils/compareResultsInReports.test.mts
@@ -93,8 +93,22 @@ describe('compareResultsInReports', () => {
     // `two` grew the same 3 kB but carries a lax `5 kB` threshold -> within.
     // `three` carries no threshold and relies on the passed fallback (2 kB) -> exceeds.
     const localReport: BundleSizeReport = [
-      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 4072, gzippedSize: 500, threshold: '2 kB' },
-      { packageName: 'two', name: 'two', path: 'two.js', minifiedSize: 4072, gzippedSize: 500, threshold: '5 kB' },
+      {
+        packageName: 'one',
+        name: 'one',
+        path: 'one.js',
+        minifiedSize: 4072,
+        gzippedSize: 500,
+        threshold: { size: 2048, type: 'size' },
+      },
+      {
+        packageName: 'two',
+        name: 'two',
+        path: 'two.js',
+        minifiedSize: 4072,
+        gzippedSize: 500,
+        threshold: { size: 5120, type: 'size' },
+      },
       { packageName: 'three', name: 'three', path: 'three.js', minifiedSize: 4072, gzippedSize: 500 },
     ];
     const remoteReport: BundleSizeReport = [
@@ -111,19 +125,5 @@ describe('compareResultsInReports', () => {
       ['two', false],
       ['three', true],
     ]);
-  });
-
-  it('throws when a captured threshold is malformed', () => {
-    const localReport: BundleSizeReport = [
-      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 4072, gzippedSize: 500, threshold: 'nonsense' },
-    ];
-    const remoteReport: BundleSizeReport = [
-      { packageName: 'one', name: 'one', path: 'one.js', minifiedSize: 1000, gzippedSize: 100 },
-    ];
-    const fallbackThreshold = { size: 2048, type: 'size' } as const;
-
-    expect(() => compareResultsInReports(localReport, remoteReport, fallbackThreshold)).toThrow(
-      /Invalid threshold value/,
-    );
   });
 });


### PR DESCRIPTION
## Summary

Makes `compare-reports` gate each package's size delta against **that package's own threshold** instead of a single root-level threshold.

Approach: the threshold is **captured into the measured JSON** during `measure` (which already runs per package and resolves the nearest `monosize.config` via `findUp`), so `compare-reports` reads each entry's own threshold with no config traversal and no storage-adapter changes.

## Behavior

Given a root `monosize.config` with a default threshold and per-package configs overriding it:

- `measure` stamps the resolved threshold onto every report entry. Override packages emit their own value; others inherit the nearest (root) config. Left unset only when no threshold is configured anywhere.
- `compare-reports` gates each entry on its captured threshold, falling back to the root/default (`10%`) when an entry has none (nothing configured, or a legacy report).

## Details

- `BundleSizeReportEntry` / `StoredReportEntry` gain an optional `threshold?: ThresholdValue`. Additive; round-trips through storage adapters unchanged.
- `measure` parses the configured threshold once (failing fast on a malformed value, where the config lives) and stamps the **parsed** `ThresholdValue` onto each entry — consistent with the rest of the report, which stores raw byte sizes rather than human strings.
- `compareResultsInReports` consumes the stored `ThresholdValue` directly (`entry.threshold ?? fallbackThreshold`) — no parsing or caching at compare time. `measure` is the single validation point.
- Config "extending root" stays userland (spread the root config in the per-package file); no merge logic added.

## Tests

- `compareResultsInReports`: per-entry gating and per-entry fallback.
- `measure`: stamps the parsed threshold onto all entries, omits when unconfigured, and fails fast on a malformed config.

Includes a beachball `minor` change file.